### PR TITLE
Add commit sha build-arg

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -152,7 +152,12 @@ export async function buildImageForHash(
 		buildLogger.info('---------------- DOCKER START ----------------');
 
 		imageStart = Date.now();
-		buildStream = await docker.buildImage(tarStream, { t: imageName });
+		buildStream = await docker.buildImage(tarStream, {
+                  t: imageName,
+                  buildargs: {
+                    commit_sha: commitHash,
+                  },
+                });
 	} catch (err) {
 		buildLogger.error(
 			{ err },


### PR DESCRIPTION
Adds the `commit_sha` arg to the build. This is used in Calypso for error reporting https://github.com/Automattic/wp-calypso/blob/b9953609301b832041de595f360c2e281192e799/bin/build-docker.js#L19

>  buildargs integer [sic]
> JSON map of string pairs for build-time variables. Users pass these values at build-time. Docker uses the buildargs as the environment context for commands run via the `Dockerfile` RUN instruction, or for variable expansion in other `Dockerfile` instructions. This is not meant for passing secret values. [Read more about the buildargs instruction](https://docs.docker.com/engine/reference/builder/#arg).

 - [Docs](https://docs.docker.com/engine/api/v1.30/#operation/ImageBuild) -- pretty sure "integer" type is wrong 🤷‍♂️ 

## Screens

### Before (live)

![before](https://user-images.githubusercontent.com/841763/35970416-8ace4bb8-0cca-11e8-8595-f8ee2d9a3682.png)

### After

![after](https://user-images.githubusercontent.com/841763/35970422-8dcfe2cc-0cca-11e8-9210-d937e1bbd694.png)

## Testing
1. Boot up a Calypso branch
1. Inspect the source for a page
1. Look for the correct commit hash like in the screens