### PR TITLE
Extract repository configuration to a config file.

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -13,6 +13,7 @@ import { Packbuilder } from 'nodegit/pack-builder';
 import { Readable } from 'stream';
 import { Container, ContainerInfo } from 'dockerode';
 
+import { config } from './config';
 import { l, getLoggerForBuild, closeLogger } from './logger';
 import { getBuildDir } from './builder';
 import { setInterval } from 'timers';
@@ -43,19 +44,13 @@ export type BranchName = string;
 export type PortNumber = number;
 export type ImageStatus = 'NoImage' | 'Inactive' | PortNumber;
 
-// TODO: move out to configuration files
-export const BUILD_LOG_FILENAME = 'dserve-build-log.txt';
-export const REPO = 'Automattic/wp-calypso';
-export const TAG_PREFIX = 'dserve-wpcalypso';
-const CLONE_PREFIX = 'git@github.com:';
-
 export const ONE_SECOND = 1000;
 export const ONE_MINUTE = 60 * ONE_SECOND;
 export const FIVE_MINUTES = 5 * ONE_MINUTE;
 export const TEN_MINUTES = 10 * ONE_MINUTE;
 export const CONTAINER_EXPIRY_TIME = FIVE_MINUTES;
 
-export const getImageName = (hash: CommitHash) => `${TAG_PREFIX}:${hash}`;
+export const getImageName = (hash: CommitHash) => `${config.build.tagPrefix}:${hash}`;
 export const extractCommitFromImage = (imageName: string): CommitHash => imageName.split(':')[1];
 
 /**
@@ -64,7 +59,10 @@ export const extractCommitFromImage = (imageName: string): CommitHash => imageNa
  */
 export async function refreshLocalImages() {
 	const images = await docker.listImages();
-	state.localImages = new Map( images.map( 
+	const isTag = (tag: string) => tag.startsWith( config.build.tagPrefix );
+	const hasTag = (image: Docker.ImageInfo) => image.RepoTags.some( isTag );
+
+	state.localImages = new Map( images.filter( hasTag ).map( 
 		image => [ image.RepoTags[0], image ] as [ string, Docker.ImageInfo ]
 	) );
 }
@@ -102,8 +100,6 @@ export async function deleteImage(hash: CommitHash) {
 	}
 }
 
-// docker run -it --name wp-calypso --rm -p 80:3000 -e
-// NODE_ENV=wpcalypso -e CALYPSO_ENV=wpcalypso wp-calypso"
 export async function startContainer(commitHash: CommitHash) {
 	l.log({ commitHash }, `Starting up container`);
 	const image = getImageName(commitHash);
@@ -115,23 +111,20 @@ export async function startContainer(commitHash: CommitHash) {
 		return;
 	}
 
+	const exposedPort = `${config.build.exposedPort}/tcp`;
 	docker.run(
 		image,
 		[],
 		process.stdout,
 		{
+			...config.build.containerCreateOptions,
+			ExposedPorts: { [exposedPort]: {} },
+			PortBindings: { [exposedPort]: [{ HostPort: freePort.toString() }] },
 			Tty: false,
-			ExposedPorts: { '3000/tcp': {} },
-			PortBindings: { '3000/tcp': [{ HostPort: freePort.toString() }] },
-			Env: ['NODE_ENV=wpcalypso', 'CALYPSO_ENV=wpcalypso'],
 		},
-		(err, succ) => {
-			if (err) {
-				l.error({ commitHash, freePort, err }, `failed starting container`);
-				return;
-			}
-			l.log({ commitHash, freePort }, `successfully started container: ${succ}`);
-		}
+		(err, succ) => err
+			? l.error({ commitHash, freePort, err }, `failed starting container`)
+			: l.log({ commitHash, freePort }, `successfully started container: ${succ}`)
 	);
 	return;
 }
@@ -168,14 +161,14 @@ async function getRemoteBranches(): Promise<Map<string, string>> {
 	let repo: git.Repository;
 
 	const start = Date.now();
-	l.log({ repository: REPO }, 'Refreshing branches list');
+	l.log({ repository: config.repo.project }, 'Refreshing branches list');
 
 	try {
 		if (!await fs.pathExists(repoDir)) {
 			await fs.mkdir(repoDir);
 		}
 		if (!await fs.pathExists(calypsoDir)) {
-			repo = await git.Clone.clone(`https://github.com/${REPO}`, calypsoDir);
+			repo = await git.Clone.clone(`https://github.com/${config.repo.project}`, calypsoDir);
 		} else {
 			repo = await git.Repository.open(calypsoDir);
 		}
@@ -212,14 +205,14 @@ async function getRemoteBranches(): Promise<Map<string, string>> {
 		} ) );
 
 		l.log(
-			{ repository: REPO, refreshBranchTime: Date.now() - start },
+			{ repository: config.repo.project, refreshBranchTime: Date.now() - start },
 			'Finished refreshing branches'
 		);
 
 		repo.free();
 		return branchToCommitHashMap;
 	} catch (err) {
-		l.error({ err, repository: REPO }, 'Error creating branchName --> commitSha map');
+		l.error({ err, repository: config.repo.project }, 'Error creating branchName --> commitSha map');
 		return;
 	}
 }
@@ -265,7 +258,7 @@ export function getExpiredContainers(containers: Array<ContainerInfo>, getAccess
 		const imageName: string = container.Image;
 
 		// exclude container if it wasnt created by this app
-		if (!imageName.startsWith(TAG_PREFIX)) {
+		if (!imageName.startsWith(config.build.tagPrefix)) {
 			return;
 		}
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -63,7 +63,7 @@ export async function refreshLocalImages() {
 	const hasTag = (image: Docker.ImageInfo) => image.RepoTags.some( isTag );
 
 	state.localImages = new Map( images.filter( hasTag ).map( 
-		image => [ image.RepoTags[0], image ] as [ string, Docker.ImageInfo ]
+		image => [ image.RepoTags.find( isTag ), image ] as [ string, Docker.ImageInfo ]
 	) );
 }
 

--- a/src/app/local-images.tsx
+++ b/src/app/local-images.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import * as ReactDOMServer from 'react-dom/server';
 import * as Docker from 'dockerode';
+import { config } from '../config';
 
 import { Shell } from './app-shell';
 import { humanSize, humanTime } from './util';
@@ -47,7 +48,7 @@ const LocalImages = ({ branchHashes, knownBranches, localImages }: RenderContext
             { Object.keys( localImages ).map( repoTags => {
                 const info = localImages[ repoTags ];
                 const createdAt = new Date( info.Created * 1000 );
-                const match = repoTags.match( /dserve-wpcalypso:([a-f0-9]+)/ );
+                const match = repoTags.match( new RegExp( `${ config.build.tagPrefix }:([a-f0-9]+)` ) );
                 const title = ( match && branchHashes.has( match[ 1 ] ) )
                     ? branchHashes.get( match[ 1 ] )
                     : repoTags;
@@ -58,7 +59,7 @@ const LocalImages = ({ branchHashes, knownBranches, localImages }: RenderContext
                             { title }{ match && (
                                 <React.Fragment>
                                     { ' - ' }
-                                    <a href={ `https://github.com/automattic/wp-calypso/commit/${ match[ 1 ] }` }>Github</a>
+                                    <a href={ `https://github.com/${ config.repo.project }/commit/${ match[ 1 ] }` }>Github</a>
                                     { ' - ' }
                                     <a href={ `/?hash=${ match[ 1 ] }` } target="_blank">Open</a>
                                 </React.Fragment>

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,35 @@
+import * as Dockerode from 'dockerode';
+
+type Readonly<T> = {
+    readonly [P in keyof T]: T[P];
+}
+type AppConfig = Readonly<{
+    build: BuildConfig;
+    repo: RepoConfig;
+}>;
+
+type BuildConfig = Readonly<{
+    containerCreateOptions?: Dockerode.ContainerCreateOptions;
+    exposedPort: number;
+    logFilename: string;
+    tagPrefix: string;
+}>;
+
+type RepoConfig = Readonly<{
+    project: string;
+}>;
+
+export const config: AppConfig = {
+    build: {
+        containerCreateOptions: {
+            Env: [ 'NODE_ENV=wpcalypso', 'CALYPSO_ENV=wpcalypso'],
+        },
+        exposedPort: 3000,
+        logFilename: 'dserve-build-log.txt',
+        tagPrefix: 'dserve-wpcalypso'
+    },
+
+    repo: {
+        project: 'Automattic/wp-calypso'
+    },
+};

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -4,6 +4,7 @@ import { Writable } from 'stream';
 
 import { CommitHash, getImageName } from './api';
 import { getLogPath } from './builder';
+import { config } from './config';
 
 const dserveLogger = bunyan.createLogger({
 	name: 'dserve',
@@ -16,6 +17,7 @@ const dserveLogger = bunyan.createLogger({
 		},
 		{
 			stream: process.stdout,
+			level: bunyan.DEBUG,
 		},
 	],
 	serializers: bunyan.stdSerializers, // allows one to use err, req, and res as special keys
@@ -24,8 +26,10 @@ const dserveLogger = bunyan.createLogger({
 
 /* super convenient name */
 export const l = {
+	// @ts-ignore need to find proper type to express passing variable args
 	log: (...args: any[]) => dserveLogger.info(...args),
-	error: (...args: any[]) => dserveLogger.error(...args),
+	// @ts-ignore need to find proper type to express passing variable args
+	error: (...args: any[]) => dserveLogger.error(...args)
 };
 
 /**
@@ -55,6 +59,7 @@ export function getLoggerForBuild(commitHash: CommitHash) {
 	// it inherits al the same properties as the parent
 	// except we don't want any of the parents streams
 	// so this line removes them all
+	// @ts-ignore this needs to be fixed with proper typing
 	((logger as any) as Logger).streams = _.filter((logger as any).streams, { path });
 
 	return logger;


### PR DESCRIPTION
There are small parts of the `dserve` codebase that specifically reference `wp-calypso`, making it less generic than it could be.  This PR extracts those parts to a config file so that `dserve` could more easily be reused with other codebases