### PR TITLE
Initial work to centralize API state

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -62,11 +62,9 @@ export const extractCommitFromImage = (imageName: string): CommitHash => imageNa
  */
 export async function refreshLocalImages() {
 	const images = await docker.listImages();
-	const nextImages = new Map();
-
-	images.forEach( image => nextImages.set( image.RepoTags, image ) );
-
-	state.localImages = nextImages;
+	state.localImages = new Map( images.map( 
+		image => [ image.RepoTags[0], image ] as [ string, Docker.ImageInfo ]
+	) );
 }
 
 /**
@@ -138,11 +136,9 @@ export async function startContainer(commitHash: CommitHash) {
 
 export async function refreshRunningContainers() {
 	const containers = await docker.listContainers();
-	const nextContainers = new Map();
-
-	containers.forEach( container => nextContainers.set( container.Image, container ) );
-
-	state.containers = nextContainers;
+	state.containers = new Map( containers.map( 
+		container => [ container.Image, container ] as [ string, ContainerInfo ] 
+	) );
 }
 
 export function isContainerRunning(hash: CommitHash) {
@@ -206,12 +202,12 @@ async function getRemoteBranches(): Promise<Map<string, string>> {
 			(x: git.Reference) => x.isBranch
 		);
 
-		const branchToCommitHashMap: Map<string, string> = new Map();
-		branchesReferences.forEach(async reference => {
+		const branchToCommitHashMap: Map<string, string> = new Map( branchesReferences.map(reference => {
 			const name = reference.shorthand().replace('origin/', '');
 			const commitHash = reference.target().tostrS();
-			branchToCommitHashMap.set(name, commitHash);
-		});
+
+			return [ name, commitHash ] as [ string, CommitHash ];
+		} ) );
 
 		l.log(
 			{ repository: REPO, refreshBranchTime: Date.now() - start },

--- a/src/api.ts
+++ b/src/api.ts
@@ -234,11 +234,11 @@ export function getCommitHashForBranch( branch: BranchName ): CommitHash | undef
 	return state.remoteBranches.get( branch );
 }
 
-export function touchCommit( hash: CommitHash ): void {
+export function touchCommit( hash: CommitHash ) {
 	state.accesses.set( hash, Date.now() );
 }
 
-export function getCommitAccessTime( hash: CommitHash ): number {
+export function getCommitAccessTime( hash: CommitHash ): number | undefined {
 	return state.accesses.get( hash );
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,8 +40,15 @@ calypsoServer.get('/log', (req: any, res: any) => {
 	const appLog = fs.readFileSync('./logs/log.txt', 'utf-8'); // todo change back from l
 	res.send(appLog);
 });
+
 calypsoServer.get('/localimages', (req: any, res: any) => {
-	const localImages = getLocalImages();
+	const localImages = Array
+		.from(getLocalImages())
+		.reduce( 
+			( images, [ repoTags, image ] ) => ( { ...images, [ repoTags ]: image } ), 
+			{} 
+		);
+
 	res.send(JSON.stringify(localImages));
 });
 


### PR DESCRIPTION
The purpose of this change is to remove the IIFE exports from `api.ts`
Along the way it's creating a centralized state atom for the API code.

Why? The reason is both to clean up code patterns but also prepare
for building a more informative and possibly interactive dashboard to
show system status.