### PR TITLE
Send HTML to browsers for `/log` and `/localimages`

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
 		"@types/react-dom": "^16.0.3",
 		"@types/strip-ansi": "^3.0.0",
 		"@types/striptags": "^3.1.1",
+		"@types/useragent": "^2.1.1",
 		"bunyan": "^1.8.12",
 		"dockerode": "^2.5.3",
 		"express": "^4.16.2",
@@ -37,7 +38,8 @@
 		"striptags": "^3.1.1",
 		"tar-fs": "^1.16.0",
 		"ts-jest": "^22.0.0",
-		"typescript": "^2.6.2"
+		"typescript": "^2.6.2",
+		"useragent": "^2.3.0"
 	},
 	"scripts": {
 		"test": "jest",

--- a/src/api.ts
+++ b/src/api.ts
@@ -20,6 +20,7 @@ import { stat } from 'fs';
 
 type APIState = {
 	accesses: Map<CommitHash, number>;
+	branchHashes: Map<CommitHash, BranchName>;
 	containers: Map<string, Docker.ContainerInfo>;
 	localImages: Map<string, Docker.ImageInfo>;
 	remoteBranches: Map<BranchName, CommitHash>;
@@ -27,6 +28,7 @@ type APIState = {
 
 const state: APIState = {
 	accesses: new Map(),
+	branchHashes: new Map(),
 	containers: new Map(),
 	localImages: new Map(),
 	remoteBranches: new Map()
@@ -226,8 +228,20 @@ export async function refreshRemoteBranches() {
 	const branches = await getRemoteBranches();
 
 	if ( branches ) {
+		state.branchHashes = new Map(
+			Array.from( branches ).map( ( [ a, b ] ) => [ b, a ] as [ CommitHash, BranchName ] )
+		);
+
 		state.remoteBranches = branches;
 	}
+}
+
+export function getBranchHashes() {
+	return state.branchHashes;
+}
+
+export function getKnownBranches() {
+	return state.remoteBranches;
 }
 
 export function getCommitHashForBranch( branch: BranchName ): CommitHash | undefined {

--- a/src/app/app-shell.tsx
+++ b/src/app/app-shell.tsx
@@ -90,17 +90,11 @@ export const Shell = ({ refreshInterval, children }: any) => (
                     text-decoration: none;
                     color: #ffffff;
                     background: #2e4453;
-                    transition: all 200ms ease-in;
                 }
 
 				.dserve-toolbar a:hover {
 					background: #ffffff;
 					color: #2e4453;
-				}
-
-				@keyframes progress-bar-animation {
-						0%   { background-position: 400px 50px; }
-						100% {  }
 				}
 		`,
 			}}

--- a/src/app/app-shell.tsx
+++ b/src/app/app-shell.tsx
@@ -1,0 +1,109 @@
+import * as React from 'react';
+
+class Reloader extends React.Component<{ milliseconds: number }> {
+	render() {
+		return (
+			<div
+				dangerouslySetInnerHTML={{
+					__html: `
+					<script>
+						setTimeout(() => window.location.reload(), ${this.props.milliseconds});
+					</script>
+				`,
+				}}
+			/>
+		);
+	}
+}
+
+export const Shell = ({ refreshInterval, children }: any) => (
+	<html>
+		<head>
+            { 'number' === typeof refreshInterval && <Reloader milliseconds={ refreshInterval } /> }
+        </head>
+		<body
+			style={{
+				fontFamily:
+					'-apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif',
+				background: '#091e25',
+				color: '#ffffff',
+				margin: '0',
+			}}
+		>
+			<div
+				className="dserve-message"
+				style={{
+					position: 'fixed',
+					width: '100%',
+					boxSizing: 'border-box',
+					minHeight: 55,
+					maxHeight: 80,
+					overflow: 'hidden',
+					padding: '16px 20px',
+					margin: 0,
+					background: '#2e4453',
+					color: '#ffffff',
+					animation: 'progress-bar-animation 3300ms infinite linear',
+					backgroundImage:
+						'linear-gradient( -45deg, #3d596d 28%, #334b5c 28%, #334b5c 72%, #3d596d 72%)',
+					backgroundSize: '200px 100%',
+					backgroundRepeat: 'repeat-x',
+					backgroundPosition: '0 50px',
+				}}
+			>
+				DServe Calypso
+				<div className="dserve-toolbar">
+                    <a href="/log">Logs</a>
+                    <a href="/localimages">Local Images</a>
+					<a href="https://github.com/Automattic/dserve/issues">Report issues</a>
+				</div>
+			</div>
+			<div
+				style={{
+					boxSizing: 'border-box',
+					width: '100%',
+					border: 0,
+					padding: '86px 20px 10px 20px',
+				}}
+			>
+                { children }
+			</div>
+		</body>
+		<style
+			dangerouslySetInnerHTML={{
+                __html: `
+                .dserve-toolbar {
+                    position: absolute;
+                    top: 12px;
+                    right: 4px;
+                    box-sizing: border-box;
+                    display: flex;
+                }
+
+                .dserve-toolbar a {
+                    display: inline-block;
+                    border: 1px solid #ffffff;
+                    border-radius: 3px;
+                    padding: 4px 6px;
+                    margin: 0 10px 0 0;
+                    fontSize: 12;
+                    text-decoration: none;
+                    color: #ffffff;
+                    background: #2e4453;
+                    transition: all 200ms ease-in;
+                }
+
+				.dserve-toolbar a:hover {
+					background: #ffffff;
+					color: #2e4453;
+				}
+
+				@keyframes progress-bar-animation {
+						0%   { background-position: 400px 50px; }
+						100% {  }
+				}
+		`,
+			}}
+		/>
+	</html>
+);

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -2,23 +2,8 @@ import * as React from 'react';
 import * as ReactDOMServer from 'react-dom/server';
 import { ONE_SECOND } from '../api';
 
+import { Shell } from './app-shell';
 import stripAnsi = require('strip-ansi');
-
-class Reloader extends React.Component<{ milliseconds: number }> {
-	render() {
-		return (
-			<div
-				dangerouslySetInnerHTML={{
-					__html: `
-					<script>
-						setTimeout(() => window.location.reload(), ${this.props.milliseconds});
-					</script>
-				`,
-				}}
-			/>
-		);
-	}
-}
 
 class BuildLog extends React.Component<{ log: string }> {
 	render() {
@@ -38,99 +23,12 @@ class BuildLog extends React.Component<{ log: string }> {
 }
 
 const App = ({ buildLog, message }: RenderContext) => (
-	<html>
-		<head />
-		<Reloader milliseconds={3 * ONE_SECOND} />
-		<body
-			style={{
-				fontFamily:
-					'-apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif',
-				background: '#091e25',
-				color: '#ffffff',
-				margin: '0',
-			}}
-		>
-			<div
-				className="dserve-message"
-				style={{
-					position: 'fixed',
-					width: '100%',
-					boxSizing: 'border-box',
-					minHeight: 55,
-					maxHeight: 80,
-					overflow: 'hidden',
-					padding: '16px 20px',
-					margin: 0,
-					background: '#2e4453',
-					color: '#ffffff',
-					animation: 'progress-bar-animation 3300ms infinite linear',
-					backgroundImage:
-						'linear-gradient( -45deg, #3d596d 28%, #334b5c 28%, #334b5c 72%, #3d596d 72%)',
-					backgroundSize: '200px 100%',
-					backgroundRepeat: 'repeat-x',
-					backgroundPosition: '0 50px',
-				}}
-			>
-				DServe Calypso
-				<div
-					className="dserve-toolbar"
-					style={{
-						position: 'absolute',
-						top: 12,
-						right: 4,
-						boxSizing: 'border-box',
-						display: 'flex',
-					}}
-				>
-					<a
-						href="https://github.com/Automattic/dserve/issues"
-						style={{
-							display: 'inline-block',
-							border: '1px solid #ffffff',
-							borderRadius: 3,
-							padding: '4px 6px',
-							margin: '0 10px 0 0',
-							fontSize: 12,
-							textDecoration: 'none',
-							color: '#ffffff',
-							background: '#2e4453',
-							transition: 'all 200ms ease-in',
-						}}
-					>
-						Report issues
-					</a>
-				</div>
-			</div>
-			<div
-				style={{
-					boxSizing: 'border-box',
-					width: '100%',
-					border: 0,
-					padding: '86px 20px 10px 20px',
-				}}
-			>
-				<pre>
-					{buildLog && <BuildLog log={buildLog} />}
-					{message && <p> {message}</p>}
-				</pre>
-			</div>
-		</body>
-		<style
-			dangerouslySetInnerHTML={{
-				__html: `
-				.dserve-toolbar:hover {
-					background: #ffffff;
-					color: #2e4453;
-				}
-
-				@keyframes progress-bar-animation {
-						0%   { background-position: 400px 50px; }
-						100% {  }
-				}
-		`,
-			}}
-		/>
-	</html>
+	<Shell refreshInterval={ 3 * ONE_SECOND }>
+		<pre>
+			{buildLog && <BuildLog log={buildLog} />}
+			{message && <p> {message}</p>}
+		</pre>
+	</Shell>
 );
 
 type RenderContext = { buildLog?: string; message?: string };

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -31,7 +31,7 @@ const App = ({ buildLog, message }: RenderContext) => (
 		<div dangerouslySetInnerHTML={ { __html: `
 			<style>
                 .dserve-toolbar a {
-					transition: all 200ms ease-in;
+					transition: background 200ms ease-in;
 				}
 
 				@keyframes progress-bar-animation {

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -28,6 +28,18 @@ const App = ({ buildLog, message }: RenderContext) => (
 			{buildLog && <BuildLog log={buildLog} />}
 			{message && <p> {message}</p>}
 		</pre>
+		<div dangerouslySetInnerHTML={ { __html: `
+			<style>
+                .dserve-toolbar a {
+					transition: all 200ms ease-in;
+				}
+
+				@keyframes progress-bar-animation {
+						0%   { background-position: 400px 50px; }
+						100% {  }
+				}
+			</style>
+		` } } />
 	</Shell>
 );
 

--- a/src/app/local-images.tsx
+++ b/src/app/local-images.tsx
@@ -2,123 +2,59 @@ import * as React from 'react';
 import * as ReactDOMServer from 'react-dom/server';
 import * as Docker from 'dockerode';
 
+import { Shell } from './app-shell';
 import { humanSize, humanTime } from './util';
+import { ONE_MINUTE } from '../api';
 
 const LocalImages = ({ localImages }: RenderContext) => (
-	<html>
-		<head />
-		<body
-			style={{
-				fontFamily:
-					'-apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif',
-				background: '#091e25',
-				color: '#ffffff',
-				margin: '0',
-			}}
-		>
-			<div
-				className="dserve-message"
-				style={{
-					position: 'fixed',
-					width: '100%',
-					boxSizing: 'border-box',
-					minHeight: 55,
-					maxHeight: 80,
-					overflow: 'hidden',
-					padding: '16px 20px',
-					margin: 0,
-					background: '#2e4453',
-					color: '#ffffff',
-					backgroundImage:
-						'linear-gradient( -45deg, #3d596d 28%, #334b5c 28%, #334b5c 72%, #3d596d 72%)',
-					backgroundSize: '200px 100%',
-					backgroundRepeat: 'repeat-x',
-					backgroundPosition: '0 50px',
-				}}
-			>
-				DServe Calypso
-				<div
-					className="dserve-toolbar"
-					style={{
-						position: 'absolute',
-						top: 12,
-						right: 4,
-						boxSizing: 'border-box',
-						display: 'flex',
-					}}
-				>
-					<a
-						href="https://github.com/Automattic/dserve/issues"
-						style={{
-							display: 'inline-block',
-							border: '1px solid #ffffff',
-							borderRadius: 3,
-							padding: '4px 6px',
-							margin: '0 10px 0 0',
-							fontSize: 12,
-							textDecoration: 'none',
-							color: '#ffffff',
-							background: '#2e4453',
-							transition: 'all 200ms ease-in',
-						}}
-					>
-						Report issues
-					</a>
-				</div>
-			</div>
-			<div
-				style={{
-					boxSizing: 'border-box',
-					width: '100%',
-					border: 0,
-					padding: '86px 20px 10px 20px',
-				}}
-			>
-                <dl>
-                { Object.keys( localImages ).map( repoTags => {
-                    const info = localImages[ repoTags ];
-                    const createdAt = new Date( info.Created * 1000 );
-                    const title = /dserve-wpcalypso:[a-f0-9]+/.test( repoTags )
-                        ? <a href={ `https://github.com/Automattic/wp-calypso/commit/${ repoTags.split( ':' )[ 1 ] }` }>{ repoTags }</a>
-                        : repoTags;
+    <Shell refreshInterval={ ONE_MINUTE }>
+        <dl>
+        { Object.keys( localImages ).map( repoTags => {
+            const info = localImages[ repoTags ];
+            const createdAt = new Date( info.Created * 1000 );
+            const match = repoTags.match( /dserve-wpcalypso:([a-f0-9]+)/ );
 
-                    return (
-                        <React.Fragment key={ info.Id }>
-                            <dt className="dserve-image-header">{ title }</dt>
-                            <dd>
-                                <p>Created <time dateTime={ createdAt.toISOString() }>{ humanTime( info.Created ) }</time></p>
-                                <p>ID { info.Id }</p>
-                                <p>Size { humanSize( info.Size ) }</p>
-                            </dd>
-                        </React.Fragment>
-                    );
-                } ) }
-                </dl>
-			</div>
-		</body>
+            return (
+                <React.Fragment key={ info.Id }>
+                    <dt className="dserve-image-header">
+                        { repoTags }{ match && (
+                            <React.Fragment>
+                                { ' - ' }
+                                <a href={ `https://github.com/automattic/wp-calypso/commit/${ match[ 1 ] }` }>Github</a>
+                                { ' - ' }
+                                <a href={ `/?hash=${ match[ 1 ] }` } target="_blank">Open</a>
+                            </React.Fragment>
+                        ) }
+                    </dt>
+                    <dd>
+                        <p>Created <time dateTime={ createdAt.toISOString() }>{ humanTime( info.Created ) }</time></p>
+                        <p>ID { info.Id }</p>
+                        <p>Size { humanSize( info.Size ) }</p>
+                    </dd>
+                </React.Fragment>
+            );
+        } ) }
+        </dl>
 		<style
 			dangerouslySetInnerHTML={{
 				__html: `
-				.dserve-toolbar:hover {
-					background: #ffffff;
-					color: #2e4453;
-				}
-                
                 .dserve-image-header {
                     color: #00d8ff;
                 }
 
                 .dserve-image-header a {
-                    color: #00d8ff;
+                    color: #fff;
                     text-decoration: none;
                 }
 
-                .dserve-image-header a:hover {
+                .dserve-image-header a:hover,
+                .dserve-image-header a:visited:hover {
+                    color: #00ff0c;
                     text-decoration: underline;
                 }
 
                 .dserve-image-header a:visited {
-                    color: #00d8ff;
+                    color: #fff;
                 }
 
                 time {
@@ -127,7 +63,7 @@ const LocalImages = ({ localImages }: RenderContext) => (
 		`,
 			}}
 		/>
-	</html>
+    </Shell>
 );
 
 type RenderContext = { localImages: { [s: string]: Docker.ImageInfo } };

--- a/src/app/local-images.tsx
+++ b/src/app/local-images.tsx
@@ -1,0 +1,103 @@
+import * as React from 'react';
+import * as ReactDOMServer from 'react-dom/server';
+import * as Docker from 'dockerode';
+
+const LocalImages = ({ localImages }: RenderContext) => (
+	<html>
+		<head />
+		<body
+			style={{
+				fontFamily:
+					'-apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif',
+				background: '#091e25',
+				color: '#ffffff',
+				margin: '0',
+			}}
+		>
+			<div
+				className="dserve-message"
+				style={{
+					position: 'fixed',
+					width: '100%',
+					boxSizing: 'border-box',
+					minHeight: 55,
+					maxHeight: 80,
+					overflow: 'hidden',
+					padding: '16px 20px',
+					margin: 0,
+					background: '#2e4453',
+					color: '#ffffff',
+					backgroundImage:
+						'linear-gradient( -45deg, #3d596d 28%, #334b5c 28%, #334b5c 72%, #3d596d 72%)',
+					backgroundSize: '200px 100%',
+					backgroundRepeat: 'repeat-x',
+					backgroundPosition: '0 50px',
+				}}
+			>
+				DServe Calypso
+				<div
+					className="dserve-toolbar"
+					style={{
+						position: 'absolute',
+						top: 12,
+						right: 4,
+						boxSizing: 'border-box',
+						display: 'flex',
+					}}
+				>
+					<a
+						href="https://github.com/Automattic/dserve/issues"
+						style={{
+							display: 'inline-block',
+							border: '1px solid #ffffff',
+							borderRadius: 3,
+							padding: '4px 6px',
+							margin: '0 10px 0 0',
+							fontSize: 12,
+							textDecoration: 'none',
+							color: '#ffffff',
+							background: '#2e4453',
+							transition: 'all 200ms ease-in',
+						}}
+					>
+						Report issues
+					</a>
+				</div>
+			</div>
+			<div
+				style={{
+					boxSizing: 'border-box',
+					width: '100%',
+					border: 0,
+					padding: '86px 20px 10px 20px',
+				}}
+			>
+                <dl>
+                { Object.keys( localImages ).map( repoTags => (
+                    <React.Fragment>
+                        <dt>{ repoTags }</dt>
+                        <dd>
+                            <pre><code>{ JSON.stringify( localImages[ repoTags ], null, 2 ) }</code></pre>
+                        </dd>
+                    </React.Fragment>
+                ) ) }
+                </dl>
+			</div>
+		</body>
+		<style
+			dangerouslySetInnerHTML={{
+				__html: `
+				.dserve-toolbar:hover {
+					background: #ffffff;
+					color: #2e4453;
+				}
+		`,
+			}}
+		/>
+	</html>
+);
+
+type RenderContext = { localImages: { [s: string]: Docker.ImageInfo } };
+export default function renderLocalImages(renderContext: RenderContext) {
+	return ReactDOMServer.renderToStaticMarkup(<LocalImages {...renderContext} />);
+}

--- a/src/app/local-images.tsx
+++ b/src/app/local-images.tsx
@@ -4,69 +4,129 @@ import * as Docker from 'dockerode';
 
 import { Shell } from './app-shell';
 import { humanSize, humanTime } from './util';
-import { ONE_MINUTE } from '../api';
+import { ONE_MINUTE, ONE_SECOND, BranchName, CommitHash } from '../api';
 
-const LocalImages = ({ localImages }: RenderContext) => (
-    <Shell refreshInterval={ ONE_MINUTE }>
-        <dl>
-        { Object.keys( localImages ).map( repoTags => {
-            const info = localImages[ repoTags ];
-            const createdAt = new Date( info.Created * 1000 );
-            const match = repoTags.match( /dserve-wpcalypso:([a-f0-9]+)/ );
+const LocalImages = ({ branchHashes, knownBranches, localImages }: RenderContext) => {
+    return (
+        <Shell refreshInterval={ knownBranches.size > 0 ? ONE_MINUTE : 5 * ONE_SECOND }>
+            <div className="dserve-branch-selector">
+                { knownBranches.size > 0 ? (
+                    <React.Fragment>
+                        <select id="selected-branch">
+                            { Array
+                                .from( knownBranches )
+                                .sort( ( a, b ) => a[0].localeCompare( b[0] ) )
+                                .map( ( [ branchName, hash ] ) => <option key={ branchName }>{ branchName }</option> )
+                            }
+                        </select>
+                        <input id="branch-selector-button" type="button" value="Open" />
+                        <div dangerouslySetInnerHTML={ { __html: `
+                            <script>
+                                (function() {
+                                    var button = document.getElementById( 'branch-selector-button' );
 
-            return (
-                <React.Fragment key={ info.Id }>
-                    <dt className="dserve-image-header">
-                        { repoTags }{ match && (
-                            <React.Fragment>
-                                { ' - ' }
-                                <a href={ `https://github.com/automattic/wp-calypso/commit/${ match[ 1 ] }` }>Github</a>
-                                { ' - ' }
-                                <a href={ `/?hash=${ match[ 1 ] }` } target="_blank">Open</a>
-                            </React.Fragment>
-                        ) }
-                    </dt>
-                    <dd>
-                        <p>Created <time dateTime={ createdAt.toISOString() }>{ humanTime( info.Created ) }</time></p>
-                        <p>ID { info.Id }</p>
-                        <p>Size { humanSize( info.Size ) }</p>
-                    </dd>
-                </React.Fragment>
-            );
-        } ) }
-        </dl>
-		<style
-			dangerouslySetInnerHTML={{
-				__html: `
-                .dserve-image-header {
-                    color: #00d8ff;
-                }
+                                    if ( button.getAttribute( 'data-has-listener' ) ) {
+                                        return;
+                                    }
 
-                .dserve-image-header a {
-                    color: #fff;
-                    text-decoration: none;
-                }
+                                    button.addEventListener( 'click', function() {
+                                        var branch = document.getElementById( 'selected-branch' );
 
-                .dserve-image-header a:hover,
-                .dserve-image-header a:visited:hover {
-                    color: #00ff0c;
-                    text-decoration: underline;
-                }
+                                        window.open(
+                                            '/?branch=' + branch.value,
+                                            '_blank'
+                                        );
+                                    } );
+                                })();
+                            </script>
+                        ` } } />
+                    </React.Fragment>
+                ) : 'Loading remote branches…' }
+            </div>
+            <dl>
+            { Object.keys( localImages ).map( repoTags => {
+                const info = localImages[ repoTags ];
+                const createdAt = new Date( info.Created * 1000 );
+                const match = repoTags.match( /dserve-wpcalypso:([a-f0-9]+)/ );
+                const title = ( match && branchHashes.has( match[ 1 ] ) )
+                    ? branchHashes.get( match[ 1 ] )
+                    : repoTags;
 
-                .dserve-image-header a:visited {
-                    color: #fff;
-                }
+                return (
+                    <React.Fragment key={ info.Id }>
+                        <dt className="dserve-image-header">
+                            { title }{ match && (
+                                <React.Fragment>
+                                    { ' - ' }
+                                    <a href={ `https://github.com/automattic/wp-calypso/commit/${ match[ 1 ] }` }>Github</a>
+                                    { ' - ' }
+                                    <a href={ `/?hash=${ match[ 1 ] }` } target="_blank">Open</a>
+                                </React.Fragment>
+                            ) }
+                        </dt>
+                        <dd>
+                            <p>Created <time dateTime={ createdAt.toISOString() }>{ humanTime( info.Created ) }</time></p>
+                            <p>ID { info.Id }</p>
+                            <p>Size { humanSize( info.Size ) }</p>
+                        </dd>
+                    </React.Fragment>
+                );
+            } ) }
+            </dl>
+            <style
+                dangerouslySetInnerHTML={{
+                    __html: `
+                    .dserve-branch-selector select,
+                    .dserve-branch-selector input[type="button"] {
+                        background: none;
+                        color: #fff;
+                        font-size: 14px;
+                    }
 
-                time {
-                    color: #00ff0c;
-                }
-		`,
-			}}
-		/>
-    </Shell>
-);
+                    .dserve-branch-selector input[type="button"] {
+                        margin-left: 8px;
+                        border-radius: 4px;
+                    }
 
-type RenderContext = { localImages: { [s: string]: Docker.ImageInfo } };
+                    .dserve-branch-selector input[type="button"]:hover {
+                        background: #fff;
+                        color: #222;
+                    }
+
+                    .dserve-image-header {
+                        color: #00d8ff;
+                    }
+
+                    .dserve-image-header a {
+                        color: #fff;
+                        text-decoration: none;
+                    }
+
+                    .dserve-image-header a:hover,
+                    .dserve-image-header a:visited:hover {
+                        color: #00ff0c;
+                        text-decoration: underline;
+                    }
+
+                    .dserve-image-header a:visited {
+                        color: #fff;
+                    }
+
+                    time {
+                        color: #00ff0c;
+                    }
+            `,
+                }}
+            />
+        </Shell>
+    );
+};
+
+type RenderContext = { 
+    branchHashes: Map<CommitHash, BranchName>;
+    knownBranches: Map<BranchName, CommitHash>;
+    localImages: { [s: string]: Docker.ImageInfo };
+};
 export default function renderLocalImages(renderContext: RenderContext) {
 	return ReactDOMServer.renderToStaticMarkup(<LocalImages {...renderContext} />);
 }

--- a/src/app/local-images.tsx
+++ b/src/app/local-images.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 import * as ReactDOMServer from 'react-dom/server';
 import * as Docker from 'dockerode';
 
+import { humanSize, humanTime } from './util';
+
 const LocalImages = ({ localImages }: RenderContext) => (
 	<html>
 		<head />
@@ -73,14 +75,24 @@ const LocalImages = ({ localImages }: RenderContext) => (
 				}}
 			>
                 <dl>
-                { Object.keys( localImages ).map( repoTags => (
-                    <React.Fragment>
-                        <dt>{ repoTags }</dt>
-                        <dd>
-                            <pre><code>{ JSON.stringify( localImages[ repoTags ], null, 2 ) }</code></pre>
-                        </dd>
-                    </React.Fragment>
-                ) ) }
+                { Object.keys( localImages ).map( repoTags => {
+                    const info = localImages[ repoTags ];
+                    const createdAt = new Date( info.Created * 1000 );
+                    const title = /dserve-wpcalypso:[a-f0-9]+/.test( repoTags )
+                        ? <a href={ `https://github.com/Automattic/wp-calypso/commit/${ repoTags.split( ':' )[ 1 ] }` }>{ repoTags }</a>
+                        : repoTags;
+
+                    return (
+                        <React.Fragment key={ info.Id }>
+                            <dt className="dserve-image-header">{ title }</dt>
+                            <dd>
+                                <p>Created <time dateTime={ createdAt.toISOString() }>{ humanTime( info.Created ) }</time></p>
+                                <p>ID { info.Id }</p>
+                                <p>Size { humanSize( info.Size ) }</p>
+                            </dd>
+                        </React.Fragment>
+                    );
+                } ) }
                 </dl>
 			</div>
 		</body>
@@ -91,6 +103,27 @@ const LocalImages = ({ localImages }: RenderContext) => (
 					background: #ffffff;
 					color: #2e4453;
 				}
+                
+                .dserve-image-header {
+                    color: #00d8ff;
+                }
+
+                .dserve-image-header a {
+                    color: #00d8ff;
+                    text-decoration: none;
+                }
+
+                .dserve-image-header a:hover {
+                    text-decoration: underline;
+                }
+
+                .dserve-image-header a:visited {
+                    color: #00d8ff;
+                }
+
+                time {
+                    color: #00ff0c;
+                }
 		`,
 			}}
 		/>

--- a/src/app/log.tsx
+++ b/src/app/log.tsx
@@ -3,10 +3,10 @@ import * as ReactDOMServer from 'react-dom/server';
 
 import { Shell } from './app-shell';
 import { errorClass, humanTime } from './util';
-import { ONE_SECOND } from '../api';
+import { ONE_MINUTE } from '../api';
 
 const Log = ({ log }: RenderContext) => (
-    <Shell refreshInterval={ 3 * ONE_SECOND }>
+    <Shell refreshInterval={ ONE_MINUTE }>
         <React.Fragment>
             <ol className="dserve-log-lines">
             { log.split( '\n' ).filter( l => l.length > 0 ).reverse().map( ( line, i ) => {

--- a/src/app/log.tsx
+++ b/src/app/log.tsx
@@ -1,133 +1,62 @@
 import * as React from 'react';
 import * as ReactDOMServer from 'react-dom/server';
 
+import { Shell } from './app-shell';
 import { errorClass, humanTime } from './util';
+import { ONE_SECOND } from '../api';
 
 const Log = ({ log }: RenderContext) => (
-	<html>
-		<head />
-		<body
-			style={{
-				fontFamily:
-					'-apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif',
-				background: '#091e25',
-				color: '#ffffff',
-				margin: '0',
-			}}
-		>
-			<div
-				className="dserve-message"
-				style={{
-					position: 'fixed',
-					width: '100%',
-					boxSizing: 'border-box',
-					minHeight: 55,
-					maxHeight: 80,
-					overflow: 'hidden',
-					padding: '16px 20px',
-					margin: 0,
-					background: '#2e4453',
-					color: '#ffffff',
-					backgroundImage:
-						'linear-gradient( -45deg, #3d596d 28%, #334b5c 28%, #334b5c 72%, #3d596d 72%)',
-					backgroundSize: '200px 100%',
-					backgroundRepeat: 'repeat-x',
-					backgroundPosition: '0 50px',
-				}}
-			>
-				DServe Calypso
-				<div
-					className="dserve-toolbar"
-					style={{
-						position: 'absolute',
-						top: 12,
-						right: 4,
-						boxSizing: 'border-box',
-						display: 'flex',
-					}}
-				>
-					<a
-						href="https://github.com/Automattic/dserve/issues"
-						style={{
-							display: 'inline-block',
-							border: '1px solid #ffffff',
-							borderRadius: 3,
-							padding: '4px 6px',
-							margin: '0 10px 0 0',
-							fontSize: 12,
-							textDecoration: 'none',
-							color: '#ffffff',
-							background: '#2e4453',
-							transition: 'all 200ms ease-in',
-						}}
-					>
-						Report issues
-					</a>
-				</div>
-			</div>
-			<div
-				style={{
-					boxSizing: 'border-box',
-					width: '100%',
-					border: 0,
-					padding: '86px 20px 10px 20px',
-				}}
-			>
-                <ol className="dserve-log-lines">
-                { log.split( '\n' ).filter( l => l.length > 0 ).reverse().map( ( line, i ) => {
-                    let data;
-                    try {
-                        data = JSON.parse( line );
-                    } catch ( e ) {
-                        return <li className="dserve-log-line" key={ `${ i }-${ line }` }>Unparseable log item - »<pre>{ line }</pre>«</li>
-                    }
-                    
-                    const at = Date.parse( data.time );
-
-                    return (
-                        <li className={ `dserve-log-line ${ errorClass( data.level ) }` } key={ `${ i }-${ line }` }>
-                            <time dateTime={ new Date( at ).toISOString() }>{ humanTime( at / 1000 ) }</time> <span>{ data.msg }</span>
-                        </li>
-                    );
-                } ) }
-                </ol>
-			</div>
-		</body>
-		<style
-			dangerouslySetInnerHTML={{
-				__html: `
-				.dserve-toolbar:hover {
-					background: #ffffff;
-					color: #2e4453;
-                }
-
-                .dserve-log-lines {
-                    list-style: none;
+    <Shell refreshInterval={ 3 * ONE_SECOND }>
+        <React.Fragment>
+            <ol className="dserve-log-lines">
+            { log.split( '\n' ).filter( l => l.length > 0 ).reverse().map( ( line, i ) => {
+                let data;
+                try {
+                    data = JSON.parse( line );
+                } catch ( e ) {
+                    return <li className="dserve-log-line" key={ `${ i }-${ line }` }>Unparseable log item - »<pre>{ line }</pre>«</li>
                 }
                 
-                .dserve-log-line {
-                    color: #00d8ff;
-                    margin-bottom: 4px;
-                }
+                const at = Date.parse( data.time );
 
-                .dserve-log-line time {
-                    color: #eee;
-                    display: inline-block;
-                    min-width: 6em;
-                    text-align: right;
-                }
+                return (
+                    <li className={ `dserve-log-line ${ errorClass( data.level ) }` } key={ `${ i }-${ line }` }>
+                        <time dateTime={ new Date( at ).toISOString() }>{ humanTime( at / 1000 ) }</time> <span>{ data.msg }</span>
+                    </li>
+                );
+            } ) }
+            </ol>
+            <style
+                dangerouslySetInnerHTML={{
+                    __html: `
+                    .dserve-log-lines {
+                        list-style: none;
+                    }
+                    
+                    .dserve-log-line {
+                        color: #00d8ff;
+                        margin-bottom: 4px;
+                    }
 
-                .dserve-log-line.error span::before {
-                    content: ' - 🚨 - ';
-                }
+                    .dserve-log-line time {
+                        color: #eee;
+                        display: inline-block;
+                        min-width: 6em;
+                        text-align: right;
+                    }
 
-                .dserve-log-line.info span::before {
-                    content: ' - ℹ - ';
-                }
-		`,
-			}}
-		/>
-	</html>
+                    .dserve-log-line.error span::before {
+                        content: ' - 🚨 - ';
+                    }
+
+                    .dserve-log-line.info span::before {
+                        content: ' - ℹ - ';
+                    }
+            `,
+                }}
+            />
+        </React.Fragment>
+    </Shell>
 );
 
 type RenderContext = { log: string };

--- a/src/app/log.tsx
+++ b/src/app/log.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import * as ReactDOMServer from 'react-dom/server';
 
+import { errorClass, humanTime } from './util';
+
 const Log = ({ log }: RenderContext) => (
 	<html>
 		<head />
@@ -71,26 +73,24 @@ const Log = ({ log }: RenderContext) => (
 					padding: '86px 20px 10px 20px',
 				}}
 			>
-                <dl>
-                { log.split( '\n' ).map( line => {
-                    let header;
+                <ol className="dserve-log-lines">
+                { log.split( '\n' ).filter( l => l.length > 0 ).map( ( line, i ) => {
                     let data;
                     try {
                         data = JSON.parse( line );
-                        header = data.msg;
                     } catch ( e ) {
-                        data = line;
-                        header = 'Unparsable log message';
+                        return <li className="dserve-log-line" key={ `${ i }-${ line }` }>Unparseable log item - »<pre>{ line }</pre>«</li>
                     }
+                    
+                    const at = Date.parse( data.time );
 
                     return (
-                        <React.Fragment>
-                            <dt className="dserve-log-header">{ header }</dt>
-                            <dd><pre><code>{ JSON.stringify( data, null, 2 ) }</code></pre></dd>
-                        </React.Fragment>
+                        <li className={ `dserve-log-line ${ errorClass( data.level ) }` } key={ `${ i }-${ line }` }>
+                            <time dateTime={ new Date( at ).toISOString() }>{ humanTime( at / 1000 ) }</time> <span>{ data.msg }</span>
+                        </li>
                     );
                 } ) }
-                </dl>
+                </ol>
 			</div>
 		</body>
 		<style
@@ -100,9 +100,29 @@ const Log = ({ log }: RenderContext) => (
 					background: #ffffff;
 					color: #2e4453;
                 }
+
+                .dserve-log-lines {
+                    list-style: none;
+                }
                 
-                .dserve-log-header {
+                .dserve-log-line {
                     color: #00d8ff;
+                    margin-bottom: 4px;
+                }
+
+                .dserve-log-line time {
+                    color: #eee;
+                    display: inline-block;
+                    min-width: 6em;
+                    text-align: right;
+                }
+
+                .dserve-log-line.error span::before {
+                    content: ' - 🚨 - ';
+                }
+
+                .dserve-log-line.info span::before {
+                    content: ' - ℹ - ';
                 }
 		`,
 			}}

--- a/src/app/log.tsx
+++ b/src/app/log.tsx
@@ -74,7 +74,7 @@ const Log = ({ log }: RenderContext) => (
 				}}
 			>
                 <ol className="dserve-log-lines">
-                { log.split( '\n' ).filter( l => l.length > 0 ).map( ( line, i ) => {
+                { log.split( '\n' ).filter( l => l.length > 0 ).reverse().map( ( line, i ) => {
                     let data;
                     try {
                         data = JSON.parse( line );

--- a/src/app/log.tsx
+++ b/src/app/log.tsx
@@ -1,0 +1,116 @@
+import * as React from 'react';
+import * as ReactDOMServer from 'react-dom/server';
+
+const Log = ({ log }: RenderContext) => (
+	<html>
+		<head />
+		<body
+			style={{
+				fontFamily:
+					'-apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif',
+				background: '#091e25',
+				color: '#ffffff',
+				margin: '0',
+			}}
+		>
+			<div
+				className="dserve-message"
+				style={{
+					position: 'fixed',
+					width: '100%',
+					boxSizing: 'border-box',
+					minHeight: 55,
+					maxHeight: 80,
+					overflow: 'hidden',
+					padding: '16px 20px',
+					margin: 0,
+					background: '#2e4453',
+					color: '#ffffff',
+					backgroundImage:
+						'linear-gradient( -45deg, #3d596d 28%, #334b5c 28%, #334b5c 72%, #3d596d 72%)',
+					backgroundSize: '200px 100%',
+					backgroundRepeat: 'repeat-x',
+					backgroundPosition: '0 50px',
+				}}
+			>
+				DServe Calypso
+				<div
+					className="dserve-toolbar"
+					style={{
+						position: 'absolute',
+						top: 12,
+						right: 4,
+						boxSizing: 'border-box',
+						display: 'flex',
+					}}
+				>
+					<a
+						href="https://github.com/Automattic/dserve/issues"
+						style={{
+							display: 'inline-block',
+							border: '1px solid #ffffff',
+							borderRadius: 3,
+							padding: '4px 6px',
+							margin: '0 10px 0 0',
+							fontSize: 12,
+							textDecoration: 'none',
+							color: '#ffffff',
+							background: '#2e4453',
+							transition: 'all 200ms ease-in',
+						}}
+					>
+						Report issues
+					</a>
+				</div>
+			</div>
+			<div
+				style={{
+					boxSizing: 'border-box',
+					width: '100%',
+					border: 0,
+					padding: '86px 20px 10px 20px',
+				}}
+			>
+                <dl>
+                { log.split( '\n' ).map( line => {
+                    let header;
+                    let data;
+                    try {
+                        data = JSON.parse( line );
+                        header = data.msg;
+                    } catch ( e ) {
+                        data = line;
+                        header = 'Unparsable log message';
+                    }
+
+                    return (
+                        <React.Fragment>
+                            <dt className="dserve-log-header">{ header }</dt>
+                            <dd><pre><code>{ JSON.stringify( data, null, 2 ) }</code></pre></dd>
+                        </React.Fragment>
+                    );
+                } ) }
+                </dl>
+			</div>
+		</body>
+		<style
+			dangerouslySetInnerHTML={{
+				__html: `
+				.dserve-toolbar:hover {
+					background: #ffffff;
+					color: #2e4453;
+                }
+                
+                .dserve-log-header {
+                    color: #00d8ff;
+                }
+		`,
+			}}
+		/>
+	</html>
+);
+
+type RenderContext = { log: string };
+export default function renderLog(renderContext: RenderContext) {
+	return ReactDOMServer.renderToStaticMarkup(<Log {...renderContext} />);
+}

--- a/src/app/util.ts
+++ b/src/app/util.ts
@@ -1,0 +1,87 @@
+export function round( a: number, digits: number ):number {
+    const scale = Math.pow( 10, digits );
+
+    return Math.round( a * scale ) / scale;
+}
+
+export function splitTime( t: number, u: number, n: number ): [ number, number ] {
+    const whole = Math.floor( t / ( u * n ) );
+    const part = Math.round( ( t - ( whole * u * n ) ) / u );
+
+    return [ whole, part ];
+}
+
+export function humanSize( size: number ): string {
+    if ( size > 1e9 ) {
+        return `${ round( size / 1e9, 2 ) } GB`;
+    }
+
+    if ( size > 1e6 ) {
+        return `${ round( size / 1e6, 1 ) } MB`;
+    }
+
+    if ( size > 1e3 ) {
+        return `${ Math.round( size / 1e3 ) } KB`;
+    }
+
+    return `${ size } B`;
+}
+
+export function humanTime( tic: number ): string {
+    const toc = Date.now() / 1000;
+    const span = ( toc - tic );
+
+    if ( span < 60 ) {
+        return `${ Math.round( span ) }s ago`;
+    }
+
+    if ( span < 60 * 60 ) {
+        const [ m, s ] = splitTime( span, 60, 1 );
+
+        return s ? `${ m }m ${ s }s ago` : `${ m }m ago`;
+    }
+
+    if ( span < 24 * 3600 ) {
+        const [ h, m ] = splitTime( span, 60, 60 );
+
+        return m ? `${ h }h ${ m }m ago` : `${ h }h ago`;
+    }
+
+    if ( span < 7 * 24 * 3600 ) {
+        const [ d, h ] = splitTime( span, 3600, 24 );
+
+        return h ? `${ d }d ${ h }h ago` : `${ d }d ago`;
+    }
+
+    if ( span < 30 * 7 * 24 * 3600 ) {
+        const [ w, d ] = splitTime( span, 24 * 3600, 7 );
+
+        return d ? `${ w }w ${ d }d ago` : `${ w }w ago`;
+    }
+
+    return `${ Math.round( span / ( 7 * 24 * 3600 ) ) }w ago`;
+}
+
+export function errorClass( errorLevel: number ): string {
+    if ( errorLevel <= 10 ) {
+        return 'trace';
+    }
+
+    if ( errorLevel <= 20 ) {
+        return 'debug';
+    }
+
+    if ( errorLevel <= 30 ) {
+        return 'info';
+    }
+
+    if ( errorLevel <= 40 ) {
+        return 'warn';
+    }
+
+    if ( errorLevel <= 50 ) {
+        return 'error';
+    }
+
+    return 'fatal';
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import * as useragent from 'useragent';
 // internal
 import {
 	getCommitHashForBranch,
+	getKnownBranches,
 	hasHashLocally,
 	CommitHash,
 	NotFound,
@@ -17,6 +18,7 @@ import {
 	proxyRequestToHash as proxy,
 	deleteImage,
 	getLocalImages,
+	getBranchHashes,
 } from './api';
 import {
 	isBuildInProgress,
@@ -48,6 +50,8 @@ calypsoServer.get('/log', (req: express.Request, res: express.Response) => {
 });
 
 calypsoServer.get('/localimages', (req: express.Request, res: express.Response) => {
+	const branchHashes = getBranchHashes();
+	const knownBranches = getKnownBranches();
 	const localImages = Array
 		.from(getLocalImages())
 		.reduce( 
@@ -56,7 +60,7 @@ calypsoServer.get('/localimages', (req: express.Request, res: express.Response) 
 		);
 
 	isBrowser( req )
-		? res.send( renderLocalImages( { localImages } ) )
+		? res.send( renderLocalImages( { branchHashes, knownBranches, localImages } ) )
 		: res.send(JSON.stringify(localImages));
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -123,6 +123,10 @@
   dependencies:
     striptags "*"
 
+"@types/useragent@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@types/useragent/-/useragent-2.1.1.tgz#e7e897f867941b03c41144f659c8f8f412a72d06"
+
 JSONStream@0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-0.10.0.tgz#74349d0d89522b71f30f0a03ff9bd20ca6f12ac0"
@@ -2296,6 +2300,13 @@ loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
   dependencies:
     js-tokens "^3.0.0"
 
+lru-cache@4.1.x:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.3.tgz#a1175cf3496dfc8436c156c334b4955992bce69c"
+  dependencies:
+    pseudomap "^1.0.2"
+    yallist "^2.1.2"
+
 lru-cache@^4.0.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.1.tgz#622e32e82488b49279114a4f9ecf45e7cd6bba55"
@@ -2667,7 +2678,7 @@ os-locale@^2.0.0:
     lcid "^1.0.0"
     mem "^1.1.0"
 
-os-tmpdir@^1.0.0, os-tmpdir@^1.0.1:
+os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
 
@@ -3557,6 +3568,12 @@ timespan@~2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/timespan/-/timespan-2.3.0.tgz#4902ce040bd13d845c8f59b27e9d59bad6f39929"
 
+tmp@0.0.x:
+  version "0.0.33"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
+  dependencies:
+    os-tmpdir "~1.0.2"
+
 tmpl@1.0.x:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.4.tgz#23640dd7b42d00433911140820e5cf440e521dd1"
@@ -3661,6 +3678,13 @@ universalify@^0.1.0:
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
+
+useragent@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/useragent/-/useragent-2.3.0.tgz#217f943ad540cb2128658ab23fc960f6a88c9972"
+  dependencies:
+    lru-cache "4.1.x"
+    tmp "0.0.x"
 
 util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
I was having trouble reading the unstyled JSON strings
So I sent HTML instead but only to the browsers

![dservisual mov](https://user-images.githubusercontent.com/5431237/39959661-3ec35968-5615-11e8-992d-51b3dd4e7fdf.gif)

Note that a fetch from something not reporting itself as a browser should still return plain JSON data.
We're parsing the user agent string from the request and if it reports as one of the selected browser families then it will return HTML instead.

```bash
curl http://localhost:3000/localimages
```