### PR TITLE
Move style tags to top of shell and sections

### DIFF
--- a/src/app/app-shell.tsx
+++ b/src/app/app-shell.tsx
@@ -20,37 +20,71 @@ export const Shell = ({ refreshInterval, children }: any) => (
 	<html>
 		<head>
             { 'number' === typeof refreshInterval && <Reloader milliseconds={ refreshInterval } /> }
-        </head>
-		<body
-			style={{
-				fontFamily:
-					'-apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif',
-				background: '#091e25',
-				color: '#ffffff',
-				margin: '0',
-			}}
-		>
-			<div
-				className="dserve-message"
-				style={{
-					position: 'fixed',
-					width: '100%',
-					boxSizing: 'border-box',
-					minHeight: 55,
-					maxHeight: 80,
-					overflow: 'hidden',
-					padding: '16px 20px',
-					margin: 0,
-					background: '#2e4453',
-					color: '#ffffff',
-					animation: 'progress-bar-animation 3300ms infinite linear',
-					backgroundImage:
-						'linear-gradient( -45deg, #3d596d 28%, #334b5c 28%, #334b5c 72%, #3d596d 72%)',
-					backgroundSize: '200px 100%',
-					backgroundRepeat: 'repeat-x',
-					backgroundPosition: '0 50px',
+			<style
+				dangerouslySetInnerHTML={{
+					__html: `
+					body {
+						font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif;
+						background: #091e25;
+						color: #ffffff;
+						margin: 0;
+					}
+
+					.dserve-toolbar {
+						position: absolute;
+						top: 12px;
+						right: 4px;
+						box-sizing: border-box;
+						display: flex;
+					}
+
+					.dserve-toolbar a {
+						display: inline-block;
+						border: 1px solid #ffffff;
+						border-radius: 3px;
+						padding: 4px 6px;
+						margin: 0 10px 0 0;
+						fontSize: 12;
+						text-decoration: none;
+						color: #ffffff;
+						background: #2e4453;
+					}
+
+					.dserve-toolbar a:hover {
+						background: #ffffff;
+						color: #2e4453;
+					}
+
+					.dserve-message {
+						position: fixed;
+						width: 100%;
+						box-sizing: border-box;
+						min-height: 55px;
+						max-height: 80px;
+						overflow: hidden;
+						padding: 16px 20px;
+						margin: 0;
+						background: #2e4453;
+						color: #ffffff;
+						animation: progress-bar-animation 3300ms infinite linear;
+						background-image: linear-gradient( -45deg, #3d596d 28%, #334b5c 28%, #334b5c 72%, #3d596d 72%);
+						background-size: 200px 100%;
+						background-repeat: repeat-x;
+						background-position: 0 50px;
+					}
+
+					.dserve-main-contents {
+						box-sizing: border-box;
+						width: 100%;
+						border: 0;
+						padding: 86px 20px 10px 20px;
+					}
+			`,
 				}}
-			>
+			/>
+        </head>
+		<body>
+			<div className="dserve-message">
 				DServe Calypso
 				<div className="dserve-toolbar">
                     <a href="/log">Logs</a>
@@ -58,46 +92,9 @@ export const Shell = ({ refreshInterval, children }: any) => (
 					<a href="https://github.com/Automattic/dserve/issues">Report issues</a>
 				</div>
 			</div>
-			<div
-				style={{
-					boxSizing: 'border-box',
-					width: '100%',
-					border: 0,
-					padding: '86px 20px 10px 20px',
-				}}
-			>
+			<div className="dserve-main-contents">
                 { children }
 			</div>
 		</body>
-		<style
-			dangerouslySetInnerHTML={{
-                __html: `
-                .dserve-toolbar {
-                    position: absolute;
-                    top: 12px;
-                    right: 4px;
-                    box-sizing: border-box;
-                    display: flex;
-                }
-
-                .dserve-toolbar a {
-                    display: inline-block;
-                    border: 1px solid #ffffff;
-                    border-radius: 3px;
-                    padding: 4px 6px;
-                    margin: 0 10px 0 0;
-                    fontSize: 12;
-                    text-decoration: none;
-                    color: #ffffff;
-                    background: #2e4453;
-                }
-
-				.dserve-toolbar a:hover {
-					background: #ffffff;
-					color: #2e4453;
-				}
-		`,
-			}}
-		/>
 	</html>
 );

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -24,10 +24,6 @@ class BuildLog extends React.Component<{ log: string }> {
 
 const App = ({ buildLog, message }: RenderContext) => (
 	<Shell refreshInterval={ 3 * ONE_SECOND }>
-		<pre>
-			{buildLog && <BuildLog log={buildLog} />}
-			{message && <p> {message}</p>}
-		</pre>
 		<div dangerouslySetInnerHTML={ { __html: `
 			<style>
                 .dserve-toolbar a {
@@ -40,6 +36,10 @@ const App = ({ buildLog, message }: RenderContext) => (
 				}
 			</style>
 		` } } />
+		<pre>
+			{buildLog && <BuildLog log={buildLog} />}
+			{message && <p> {message}</p>}
+		</pre>
 	</Shell>
 );
 

--- a/src/app/local-images.tsx
+++ b/src/app/local-images.tsx
@@ -7,121 +7,119 @@ import { Shell } from './app-shell';
 import { humanSize, humanTime } from './util';
 import { ONE_MINUTE, ONE_SECOND, BranchName, CommitHash } from '../api';
 
-const LocalImages = ({ branchHashes, knownBranches, localImages }: RenderContext) => {
-    return (
-        <Shell refreshInterval={ knownBranches.size > 0 ? ONE_MINUTE : 5 * ONE_SECOND }>
-            <div className="dserve-branch-selector">
-                { knownBranches.size > 0 ? (
-                    <React.Fragment>
-                        <select id="selected-branch">
-                            { Array
-                                .from( knownBranches )
-                                .sort( ( a, b ) => a[0].localeCompare( b[0] ) )
-                                .map( ( [ branchName, hash ] ) => <option key={ branchName }>{ branchName }</option> )
-                            }
-                        </select>
-                        <input id="branch-selector-button" type="button" value="Open" />
-                        <div dangerouslySetInnerHTML={ { __html: `
-                            <script>
-                                (function() {
-                                    var button = document.getElementById( 'branch-selector-button' );
+const LocalImages = ({ branchHashes, knownBranches, localImages }: RenderContext) => (
+    <Shell refreshInterval={ knownBranches.size > 0 ? ONE_MINUTE : 5 * ONE_SECOND }>
+        <style
+            dangerouslySetInnerHTML={{
+                __html: `
+                .dserve-branch-selector select,
+                .dserve-branch-selector input[type="button"] {
+                    background: none;
+                    color: #fff;
+                    font-size: 14px;
+                }
 
-                                    if ( button.getAttribute( 'data-has-listener' ) ) {
-                                        return;
-                                    }
+                .dserve-branch-selector input[type="button"] {
+                    margin-left: 8px;
+                    border-radius: 4px;
+                }
 
-                                    button.addEventListener( 'click', function() {
-                                        var branch = document.getElementById( 'selected-branch' );
+                .dserve-branch-selector input[type="button"]:hover {
+                    background: #fff;
+                    color: #222;
+                }
 
-                                        window.open(
-                                            '/?branch=' + branch.value,
-                                            '_blank'
-                                        );
-                                    } );
-                                })();
-                            </script>
-                        ` } } />
-                    </React.Fragment>
-                ) : 'Loading remote branches…' }
-            </div>
-            <dl>
-            { Object.keys( localImages ).map( repoTags => {
-                const info = localImages[ repoTags ];
-                const createdAt = new Date( info.Created * 1000 );
-                const match = repoTags.match( new RegExp( `${ config.build.tagPrefix }:([a-f0-9]+)` ) );
-                const title = ( match && branchHashes.has( match[ 1 ] ) )
-                    ? branchHashes.get( match[ 1 ] )
-                    : repoTags;
+                .dserve-image-header {
+                    color: #00d8ff;
+                }
 
-                return (
-                    <React.Fragment key={ info.Id }>
-                        <dt className="dserve-image-header">
-                            { title }{ match && (
-                                <React.Fragment>
-                                    { ' - ' }
-                                    <a href={ `https://github.com/${ config.repo.project }/commit/${ match[ 1 ] }` }>Github</a>
-                                    { ' - ' }
-                                    <a href={ `/?hash=${ match[ 1 ] }` } target="_blank">Open</a>
-                                </React.Fragment>
-                            ) }
-                        </dt>
-                        <dd>
-                            <p>Created <time dateTime={ createdAt.toISOString() }>{ humanTime( info.Created ) }</time></p>
-                            <p>ID { info.Id }</p>
-                            <p>Size { humanSize( info.Size ) }</p>
-                        </dd>
-                    </React.Fragment>
-                );
-            } ) }
-            </dl>
-            <style
-                dangerouslySetInnerHTML={{
-                    __html: `
-                    .dserve-branch-selector select,
-                    .dserve-branch-selector input[type="button"] {
-                        background: none;
-                        color: #fff;
-                        font-size: 14px;
-                    }
+                .dserve-image-header a {
+                    color: #fff;
+                    text-decoration: none;
+                }
 
-                    .dserve-branch-selector input[type="button"] {
-                        margin-left: 8px;
-                        border-radius: 4px;
-                    }
+                .dserve-image-header a:hover,
+                .dserve-image-header a:visited:hover {
+                    color: #00ff0c;
+                    text-decoration: underline;
+                }
 
-                    .dserve-branch-selector input[type="button"]:hover {
-                        background: #fff;
-                        color: #222;
-                    }
+                .dserve-image-header a:visited {
+                    color: #fff;
+                }
 
-                    .dserve-image-header {
-                        color: #00d8ff;
-                    }
+                time {
+                    color: #00ff0c;
+                }
+        `,
+            }}
+        />
+        <div className="dserve-branch-selector">
+            { knownBranches.size > 0 ? (
+                <React.Fragment>
+                    <select id="selected-branch">
+                        { Array
+                            .from( knownBranches )
+                            .sort( ( a, b ) => a[0].localeCompare( b[0] ) )
+                            .map( ( [ branchName, hash ] ) => <option key={ branchName }>{ branchName }</option> )
+                        }
+                    </select>
+                    <input id="branch-selector-button" type="button" value="Open" />
+                    <div dangerouslySetInnerHTML={ { __html: `
+                        <script>
+                            (function() {
+                                var button = document.getElementById( 'branch-selector-button' );
 
-                    .dserve-image-header a {
-                        color: #fff;
-                        text-decoration: none;
-                    }
+                                if ( button.getAttribute( 'data-has-listener' ) ) {
+                                    return;
+                                }
 
-                    .dserve-image-header a:hover,
-                    .dserve-image-header a:visited:hover {
-                        color: #00ff0c;
-                        text-decoration: underline;
-                    }
+                                button.addEventListener( 'click', function() {
+                                    var branch = document.getElementById( 'selected-branch' );
 
-                    .dserve-image-header a:visited {
-                        color: #fff;
-                    }
+                                    window.open(
+                                        '/?branch=' + branch.value,
+                                        '_blank'
+                                    );
+                                } );
+                            })();
+                        </script>
+                    ` } } />
+                </React.Fragment>
+            ) : 'Loading remote branches…' }
+        </div>
+        <dl>
+        { Object.keys( localImages ).map( repoTags => {
+            const info = localImages[ repoTags ];
+            const createdAt = new Date( info.Created * 1000 );
+            const match = repoTags.match( new RegExp( `${ config.build.tagPrefix }:([a-f0-9]+)` ) );
+            const title = ( match && branchHashes.has( match[ 1 ] ) )
+                ? branchHashes.get( match[ 1 ] )
+                : repoTags;
 
-                    time {
-                        color: #00ff0c;
-                    }
-            `,
-                }}
-            />
-        </Shell>
-    );
-};
+            return (
+                <React.Fragment key={ info.Id }>
+                    <dt className="dserve-image-header">
+                        { title }{ match && (
+                            <React.Fragment>
+                                { ' - ' }
+                                <a href={ `https://github.com/${ config.repo.project }/commit/${ match[ 1 ] }` }>Github</a>
+                                { ' - ' }
+                                <a href={ `/?hash=${ match[ 1 ] }` } target="_blank">Open</a>
+                            </React.Fragment>
+                        ) }
+                    </dt>
+                    <dd>
+                        <p>Created <time dateTime={ createdAt.toISOString() }>{ humanTime( info.Created ) }</time></p>
+                        <p>ID { info.Id }</p>
+                        <p>Size { humanSize( info.Size ) }</p>
+                    </dd>
+                </React.Fragment>
+            );
+        } ) }
+        </dl>
+    </Shell>
+);
 
 type RenderContext = { 
     branchHashes: Map<CommitHash, BranchName>;

--- a/src/app/log.tsx
+++ b/src/app/log.tsx
@@ -7,55 +7,53 @@ import { ONE_MINUTE } from '../api';
 
 const Log = ({ log }: RenderContext) => (
     <Shell refreshInterval={ ONE_MINUTE }>
-        <React.Fragment>
-            <ol className="dserve-log-lines">
-            { log.split( '\n' ).filter( l => l.length > 0 ).reverse().map( ( line, i ) => {
-                let data;
-                try {
-                    data = JSON.parse( line );
-                } catch ( e ) {
-                    return <li className="dserve-log-line" key={ `${ i }-${ line }` }>Unparseable log item - »<pre>{ line }</pre>«</li>
+        <style
+            dangerouslySetInnerHTML={{
+                __html: `
+                .dserve-log-lines {
+                    list-style: none;
                 }
                 
-                const at = Date.parse( data.time );
+                .dserve-log-line {
+                    color: #00d8ff;
+                    margin-bottom: 4px;
+                }
 
-                return (
-                    <li className={ `dserve-log-line ${ errorClass( data.level ) }` } key={ `${ i }-${ line }` }>
-                        <time dateTime={ new Date( at ).toISOString() }>{ humanTime( at / 1000 ) }</time> <span>{ data.msg }</span>
-                    </li>
-                );
-            } ) }
-            </ol>
-            <style
-                dangerouslySetInnerHTML={{
-                    __html: `
-                    .dserve-log-lines {
-                        list-style: none;
-                    }
-                    
-                    .dserve-log-line {
-                        color: #00d8ff;
-                        margin-bottom: 4px;
-                    }
+                .dserve-log-line time {
+                    color: #eee;
+                    display: inline-block;
+                    min-width: 6em;
+                    text-align: right;
+                }
 
-                    .dserve-log-line time {
-                        color: #eee;
-                        display: inline-block;
-                        min-width: 6em;
-                        text-align: right;
-                    }
+                .dserve-log-line.error span::before {
+                    content: ' - 🚨 - ';
+                }
 
-                    .dserve-log-line.error span::before {
-                        content: ' - 🚨 - ';
-                    }
+                .dserve-log-line.info span::before {
+                    content: ' - ℹ - ';
+                }
+        `,
+            }}
+        />
+        <ol className="dserve-log-lines">
+        { log.split( '\n' ).filter( l => l.length > 0 ).reverse().map( ( line, i ) => {
+            let data;
+            try {
+                data = JSON.parse( line );
+            } catch ( e ) {
+                return <li className="dserve-log-line" key={ `${ i }-${ line }` }>Unparseable log item - »<pre>{ line }</pre>«</li>
+            }
+            
+            const at = Date.parse( data.time );
 
-                    .dserve-log-line.info span::before {
-                        content: ' - ℹ - ';
-                    }
-            `,
-                }}
-            />
-        </React.Fragment>
+            return (
+                <li className={ `dserve-log-line ${ errorClass( data.level ) }` } key={ `${ i }-${ line }` }>
+                    <time dateTime={ new Date( at ).toISOString() }>{ humanTime( at / 1000 ) }</time> <span>{ data.msg }</span>
+                </li>
+            );
+        } ) }
+        </ol>
     </Shell>
 );
 


### PR DESCRIPTION
When I deployed to production in #22 I noticed a flash
of context when the page loaded and I believe that the
reason is that it takes longer to load the larger list
of branches than it does on my local machine, and when
the stylesheets are all at the end they don't yet load
until the rest of the page has as well.

In this patch I'm moving styles to the top in hopes
that the browser will parse those immediately and
eliminate the flash of unstyled content.

**Testing**

No real testing other than smoke-testing - make sure
it doesn't entirely crash. The intended effect is that
the flash goes away and I'm not sure how to test outside
of production because I don't think that I have the room
to build fifty images locally.