### PR TITLE
Add runtime clock

### DIFF
--- a/src/app/app-shell.tsx
+++ b/src/app/app-shell.tsx
@@ -1,4 +1,6 @@
 import * as React from 'react';
+import { start } from 'repl';
+import { humanTime } from './util';
 
 class Reloader extends React.Component<{ milliseconds: number }> {
 	render() {
@@ -16,7 +18,7 @@ class Reloader extends React.Component<{ milliseconds: number }> {
 	}
 }
 
-export const Shell = ({ refreshInterval, children }: any) => (
+export const Shell = ({ refreshInterval, startedServerAt, children }: any) => (
 	<html>
 		<head>
             { 'number' === typeof refreshInterval && <Reloader milliseconds={ refreshInterval } /> }
@@ -85,7 +87,7 @@ export const Shell = ({ refreshInterval, children }: any) => (
         </head>
 		<body>
 			<div className="dserve-message">
-				DServe Calypso
+				DServe Calypso - <time dateTime={ startedServerAt.toISOString() }>{ humanTime( startedServerAt / 1000 ) }</time>
 				<div className="dserve-toolbar">
                     <a href="/log">Logs</a>
                     <a href="/localimages">Local Images</a>

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -22,8 +22,8 @@ class BuildLog extends React.Component<{ log: string }> {
 	}
 }
 
-const App = ({ buildLog, message }: RenderContext) => (
-	<Shell refreshInterval={ 3 * ONE_SECOND }>
+const App = ({ buildLog, message, startedServerAt }: RenderContext) => (
+	<Shell refreshInterval={ 3 * ONE_SECOND } startedServerAt={ startedServerAt }>
 		<div dangerouslySetInnerHTML={ { __html: `
 			<style>
                 .dserve-toolbar a {
@@ -43,7 +43,7 @@ const App = ({ buildLog, message }: RenderContext) => (
 	</Shell>
 );
 
-type RenderContext = { buildLog?: string; message?: string };
+type RenderContext = { buildLog?: string; message?: string, startedServerAt: Date };
 export default function renderApp(renderContext: RenderContext) {
 	return ReactDOMServer.renderToStaticNodeStream(<App {...renderContext} />);
 }

--- a/src/app/local-images.tsx
+++ b/src/app/local-images.tsx
@@ -7,8 +7,8 @@ import { Shell } from './app-shell';
 import { humanSize, humanTime } from './util';
 import { ONE_MINUTE, ONE_SECOND, BranchName, CommitHash } from '../api';
 
-const LocalImages = ({ branchHashes, knownBranches, localImages }: RenderContext) => (
-    <Shell refreshInterval={ knownBranches.size > 0 ? ONE_MINUTE : 5 * ONE_SECOND }>
+const LocalImages = ({ branchHashes, knownBranches, localImages, startedServerAt }: RenderContext) => (
+    <Shell refreshInterval={ knownBranches.size > 0 ? ONE_MINUTE : 5 * ONE_SECOND } startedServerAt={ startedServerAt }>
         <style
             dangerouslySetInnerHTML={{
                 __html: `
@@ -125,6 +125,7 @@ type RenderContext = {
     branchHashes: Map<CommitHash, BranchName>;
     knownBranches: Map<BranchName, CommitHash>;
     localImages: { [s: string]: Docker.ImageInfo };
+    startedServerAt: Date;
 };
 export default function renderLocalImages(renderContext: RenderContext) {
 	return ReactDOMServer.renderToStaticMarkup(<LocalImages {...renderContext} />);

--- a/src/app/log.tsx
+++ b/src/app/log.tsx
@@ -5,8 +5,8 @@ import { Shell } from './app-shell';
 import { errorClass, humanTime } from './util';
 import { ONE_MINUTE } from '../api';
 
-const Log = ({ log }: RenderContext) => (
-    <Shell refreshInterval={ ONE_MINUTE }>
+const Log = ({ log, startedServerAt }: RenderContext) => (
+    <Shell refreshInterval={ ONE_MINUTE } startedServerAt={ startedServerAt }>
         <style
             dangerouslySetInnerHTML={{
                 __html: `
@@ -57,7 +57,7 @@ const Log = ({ log }: RenderContext) => (
     </Shell>
 );
 
-type RenderContext = { log: string };
+type RenderContext = { log: string, startedServerAt: Date };
 export default function renderLog(renderContext: RenderContext) {
 	return ReactDOMServer.renderToStaticMarkup(<Log {...renderContext} />);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,8 @@ import renderLog from './app/log';
 import { l } from './logger';
 import { Writable } from 'stream';
 
+const startedServerAt = new Date();
+
 // calypso proxy server.
 // checks branch names, decides to start a build or a container,
 // and also proxies request to currently active container
@@ -45,7 +47,7 @@ calypsoServer.get('/log', (req: express.Request, res: express.Response) => {
 	const appLog = fs.readFileSync('./logs/log.txt', 'utf-8'); // todo change back from l
 
 	isBrowser( req )
-		? res.send( renderLog( { log: appLog } ) )
+		? res.send( renderLog( { log: appLog, startedServerAt } ) )
 		: res.send(appLog);
 });
 
@@ -60,7 +62,7 @@ calypsoServer.get('/localimages', (req: express.Request, res: express.Response) 
 		);
 
 	isBrowser( req )
-		? res.send( renderLocalImages( { branchHashes, knownBranches, localImages } ) )
+		? res.send( renderLocalImages( { branchHashes, knownBranches, localImages, startedServerAt } ) )
 		: res.send(JSON.stringify(localImages));
 });
 
@@ -116,7 +118,7 @@ calypsoServer.get('*', async (req: any, res: any) => {
 		await startContainer(commitHash);
 	}
 
-	renderApp({ message, buildLog }).pipe(res);
+	renderApp({ message, buildLog, startedServerAt }).pipe(res);
 });
 
 calypsoServer.listen(3000, () => l.log('dserve is listening on 3000'));


### PR DESCRIPTION
Shows the total time running and when the server last started in the app
shell. Adds the appropriate data passing through the React widgets to
make it happen.