### PR TITLE
API Tasks: Contain background loops in closure (no setInterval)

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -302,14 +302,14 @@ export async function proxyRequestToHash(req: any, res: any) {
 }
 
 if (process.env.NODE_ENV !== 'test') {
-	// first run
-	refreshLocalImages();
-	refreshRunningContainers();
-	refreshRemoteBranches();
+	const loop = ( f: Function, delay: number ) => {
+		const run = async () => ( await f(), setTimeout( run, delay ) );
 
-	// setup for future
-	setInterval(cleanupExpiredContainers, TEN_MINUTES);
-	setInterval(refreshLocalImages, ONE_SECOND);
-	setInterval(refreshRunningContainers, ONE_SECOND);
-	setInterval(refreshRemoteBranches, ONE_MINUTE);
+		run();
+	}
+
+	loop( refreshLocalImages, 5 * ONE_SECOND );
+	loop( refreshRunningContainers, 5 * ONE_SECOND );
+	loop( refreshRemoteBranches, ONE_MINUTE );
+	loop( cleanupExpiredContainers, TEN_MINUTES );
 }


### PR DESCRIPTION
The API system runs four tasks in the background on a regular basis.
These tasks update the list of remote branches, local images, etc...
Previously we have been using `setInterval()` to have them run at a
pace every so often, but that leaves open a timing error where if
the task doesn't finish before the interval fires again then we'll
start stacking up the tasks on top of one another.

In this patch I'm replacing the `setInterval()` with a `setTimeout()`
sequence that only schedules the next run of the task once the first
call has completed. This could mean that tasks don't run as often as
we intend but it does guard against this overlapping scheduling.

For example, if `docker` is slow to respond it could take longer than
a few seconds to return the list of local images. In this case we may
end up waiting many seconds or even a minute between updates, but as
the code was, we would queue multiple updates from `docker` which
would end up slowing things down even further when the system is at
load.