### PR TITLE
Add time tooltips where appropriate

### DIFF
--- a/src/app/app-shell.tsx
+++ b/src/app/app-shell.tsx
@@ -87,7 +87,12 @@ export const Shell = ({ refreshInterval, startedServerAt, children }: any) => (
         </head>
 		<body>
 			<div className="dserve-message">
-				DServe Calypso - <time dateTime={ startedServerAt.toISOString() }>{ humanTime( startedServerAt / 1000 ) }</time>
+				DServe Calypso - { (
+					<time
+						dateTime={ startedServerAt.toISOString() }
+						title={ startedServerAt.toLocaleTimeString( undefined, { timeZoneName: 'long', hour12: true } ) }
+					>{ humanTime( startedServerAt / 1000 ) }</time>
+				) }
 				<div className="dserve-toolbar">
                     <a href="/log">Logs</a>
                     <a href="/localimages">Local Images</a>

--- a/src/app/local-images.tsx
+++ b/src/app/local-images.tsx
@@ -110,7 +110,12 @@ const LocalImages = ({ branchHashes, knownBranches, localImages, startedServerAt
                         ) }
                     </dt>
                     <dd>
-                        <p>Created <time dateTime={ createdAt.toISOString() }>{ humanTime( info.Created ) }</time></p>
+                        <p>Created { (
+                            <time
+                                dateTime={ createdAt.toISOString() }
+                                title={ createdAt.toLocaleTimeString( undefined, { timeZoneName: 'long', hour12: true } ) }
+                            >{ humanTime( info.Created ) }</time>
+                        ) }</p>
                         <p>ID { info.Id }</p>
                         <p>Size { humanSize( info.Size ) }</p>
                     </dd>

--- a/src/app/log.tsx
+++ b/src/app/log.tsx
@@ -49,7 +49,10 @@ const Log = ({ log, startedServerAt }: RenderContext) => (
 
             return (
                 <li className={ `dserve-log-line ${ errorClass( data.level ) }` } key={ `${ i }-${ line }` }>
-                    <time dateTime={ new Date( at ).toISOString() }>{ humanTime( at / 1000 ) }</time> <span>{ data.msg }</span>
+                    <time
+                        dateTime={ new Date( at ).toISOString() }
+                        title={ new Date( at ).toLocaleTimeString( undefined, { timeZoneName: 'long', hour12: true } ) }
+                    >{ humanTime( at / 1000 ) }</time> <span>{ data.msg }</span>
                 </li>
             );
         } ) }

--- a/src/index.ts
+++ b/src/index.ts
@@ -121,7 +121,9 @@ calypsoServer.get('*', async (req: any, res: any) => {
 	renderApp({ message, buildLog, startedServerAt }).pipe(res);
 });
 
-calypsoServer.listen(3000, () => l.log('dserve is listening on 3000'));
+calypsoServer.listen(3000, () => l.log(
+	`✅ dserve is listening on 3000 - started at ${ startedServerAt.toLocaleTimeString( undefined, { timeZoneName: 'long', hour12: true }) }`)
+);
 
 function isBrowser( req: express.Request ): Boolean {
 	const ua = useragent.lookup( req.header( 'user-agent' ) );


### PR DESCRIPTION
Adds `title` attribute to `<time>` tags to reveal formatted local time
on hover. Previously nothing would show the local time. Also adds
formatted local time to server-start message in log.