### PR TITLE
Route unhandled rejections and exceptions to the log

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,14 @@ import renderLog from './app/log';
 import { l } from './logger';
 import { Writable } from 'stream';
 
+process.on( 'unhandledRejection', ( reason, p ) => {
+	l.error( reason, 'Unhandled rejection! %s', reason );
+});
+
+process.on( 'uncaughtException', ( ex ) => {
+	l.error( ex, 'Uncaught exception' );
+} );
+
 const startedServerAt = new Date();
 
 // calypso proxy server.


### PR DESCRIPTION
Instead of just dropping them, push unhandled promise rejections and exceptions to the log.