### PR TITLE
Report uncaught exceptions

### DIFF
--- a/src/app/debug.tsx
+++ b/src/app/debug.tsx
@@ -2,9 +2,10 @@ import * as React from 'react';
 import * as ReactDOMServer from 'react-dom/server';
 import * as os from 'os';
 
-import { Shell } from './app-shell';
-import { humanSize, percent, round } from './util';
 import { ONE_MINUTE } from '../api';
+import { Shell } from './app-shell';
+import { promiseRejections } from '../index';
+import { humanSize, humanTime, percent, round } from './util';
 
 import { state as apiState } from '../api';
 import { BUILD_QUEUE } from '../builder';
@@ -67,6 +68,24 @@ const Debug = ( c: RenderContext ) => {
                         <p><em>Nothing is waiting in the queue</em></p>
                     ) }
                     <figcaption>Builder</figcaption>
+                </figure>
+
+                <figure>
+                    { promiseRejections.size ? (
+                        <ul>
+                            { Array.from( promiseRejections.values() ).map( ( [ ts, reason, ] ) => (
+                                <li>
+                                    <time dateTime={ ts.toISOString() } title={ ts.toLocaleTimeString( undefined, { timeZoneName: 'long', hour12: true } ) }>
+                                        { humanTime( ts.getTime() / 1000 ) }
+                                    </time>
+                                    { reason }
+                                </li>
+                            ) ) }
+                        </ul>
+                    ) : (
+                        <p><em>No unhandled rejected promises</em></p>
+                    ) }
+                    <figcaption>Rejected Promises</figcaption>
                 </figure>
 
                 <figure>

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,14 +35,6 @@ import renderDebug from './app/debug';
 import { l } from './logger';
 import { Writable } from 'stream';
 
-process.on( 'unhandledRejection', ( reason, p ) => {
-	l.error( reason, 'Unhandled rejection! %s', reason );
-});
-
-process.on( 'uncaughtException', ( ex ) => {
-	l.error( ex, 'Uncaught exception' );
-} );
-
 const startedServerAt = new Date();
 
 // calypso proxy server.


### PR DESCRIPTION
Tracks and reports uncaught exceptions and unhandled promise rejections.
Also adds a listing of unhandled promise rejections to the debug screen.
Unhandled promise rejections can linger around and come and go so in
this case we don't just report them as they come but rather wait for a
bit and see if they linger.