### PR TITLE
Debug: Show all docker images and containers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -88,7 +88,7 @@ calypsoServer.get('/localimages', (req: express.Request, res: express.Response) 
 });
 
 calypsoServer.get('/debug', async (req: express.Request, res: express.Response) => {
-	res.send( renderDebug( {
+	res.send( await renderDebug( {
 		startedServerAt,
 	} ) ) 
 } );


### PR DESCRIPTION
We have issues losing images/containers. This information isn't
being displayed in the debug view because we're only showing the
information we are aware of as being `dserve` images.

In this patch we're making explicit calls to Docker at the time of
render in order to make sure that we get reasonably up-to-date data
from the system and in order to show all images regardless of their
tagging.

This should help us diagnose issues where we are getting unlinked
or stray images that we don't need.