### PR TITLE
Debug: Align figures at top

### DIFF
--- a/src/app/debug.tsx
+++ b/src/app/debug.tsx
@@ -40,8 +40,7 @@ const Debug = (c: RenderContext) => {
                         border: 1px solid gray;
                         border-radius: 4px;
                         padding: 8px;
-                        margin: auto;
-                        margin-bottom: 16px;
+                        margin-bottom: auto;
                     }
 
                     .dserve-debug-cards figure figcaption {


### PR DESCRIPTION
Previously there was a mistake in the CSS which caused the figure
cards to align at the bottom of their rows. This was caused when
`margin: auto` would assign a top margin very high.

This has been fixed to only set the buttom margin automatically.