### PR TITLE
DO NOT MERGE: Adds ability to remove images and containers

### DIFF
--- a/src/app/debug.tsx
+++ b/src/app/debug.tsx
@@ -131,7 +131,7 @@ const Debug = (c: RenderContext) => {
                     <ul>
                         {images.map(([key, info]) => (
                             <li key={info.Id}>
-                                RepoTags: <strong>{shortHash(info.RepoTags.join(', '), 38)}</strong><br />
+                                RepoTags: <strong>{shortHash(info.RepoTags.join(', ') )}</strong><br />
                                 Id: {shortHash(info.Id)}<br />
                                 Size: {humanSize(info.Size)}<br />
                                 Created: {humanTime(info.Created)}
@@ -153,6 +153,9 @@ const Debug = (c: RenderContext) => {
                                         <strong>{info.Names}</strong> - {shortHash(info.Id)}<br />
                                         Image ID: {shortHash(info.ImageID)}<br />
                                         Status: {info.State} - {info.Status}
+                                        <form method="post">
+                                            <button formAction={ `/containers/${ info.Id }?action=delete` } type="submit">🤯 Remove</button>
+                                        </form>
                                     </li>
                                 ))
                         )}
@@ -165,10 +168,13 @@ const Debug = (c: RenderContext) => {
                                 .sort((a, b) => b.Created - a.Created)
                                 .map(info => (
                                     <li key={info.Id}>
-                                        RepoTags: <strong>{shortHash(info.RepoTags.join(', '), 38)}</strong><br />
+                                        RepoTags: <strong>{shortHash(info.RepoTags.join(', ') )}</strong><br />
                                         Id: {shortHash(info.Id)}<br />
                                         Size: {humanSize(info.Size)}<br />
-                                        Created: {humanTime(info.Created)}
+                                        Created: {humanTime(info.Created)}<br />
+                                        <form method="post">
+                                            <button formAction={ `/images/${ info.Id }` } type="submit">🤯 Remove</button>
+                                        </form>
                                     </li>
                                 ))
                         )}


### PR DESCRIPTION
**DO NOT MERGE**

This is a work-in-progress patch to allow the manual removal of any
image or container on the running server from the `/debug` page.

This _would_ be working except it introduces a bug: when we delete
by container or image id we leave behind the build directory for the
commit hash the container or image was originally associated with. This
means that whenever someone tries to load this commit hash again
then `dserve` will thing the container is being build.

We need to associate build dirs not only with commit hash but also
with the images they build or make sure to delete them after the
images themselves are finished building.