### PR TITLE
Prevent creating a new container while one is spinning up

### DIFF
--- a/src/app/log.tsx
+++ b/src/app/log.tsx
@@ -14,6 +14,7 @@ const interestingDetails = new Set([
     'containerId',
     'cloneTime',
     'checkoutTime',
+    'success',
 ]);
 
 const LogDetails = ( { data  } : any ) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -139,10 +139,17 @@ calypsoServer.get('*', async (req: any, res: any) => {
 		message = 'Starting build now';
 		addToBuildQueue(commitHash);
 	} else if (shouldStartContainer) {
-		message = 'Just started your hash, this page will restart automatically';
+		//message = 'Just started your hash, this page will restart automatically';
 		// TODO: fix race condition where multiple containers may be spun up
 		// within the same subsecond time period.
-		await startContainer(commitHash);
+		try { 
+			await startContainer(commitHash);
+			proxy( req, res );
+			return;
+		} catch( err ) {
+			message = 'Error starting that commit...';
+			l.error( { err }, 'Error starting commit' );
+		}
 	}
 
 	renderApp({ message, buildLog, startedServerAt }).pipe(res);


### PR DESCRIPTION
This changes how we spin up a container for an image. 

Previously, we would blindly spin up a new container when asked. This changes that to be aware of containers being spun up per commit hash, and to be aware of running containers.

* If a request comes in to start a container and we have nothing spinning up or running, we spin up a new container.
* If we're spinning up a container, we hand back a promise that will fulfill when that containers comes up, or fails
* If we have a running container, we hand back a promise that describes that container.