### PR TITLE
Try using the unpublished nodegit thread safety switch

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -17,6 +17,11 @@ import {
 import { config } from './config';
 import { closeLogger, l, getLoggerForBuild } from './logger';
 
+
+// hidden method in nodegit that turns on thread safety
+// see https://github.com/nodegit/nodegit/pull/836
+(git as any).enableThreadSafety();
+
 export const MAX_CONCURRENT_BUILDS = 3;
 export const buildQueue: Array<CommitHash> = [];
 const pendingHashes: Set<CommitHash> = new Set();

--- a/test/__mocks__/nodegit.js
+++ b/test/__mocks__/nodegit.js
@@ -3,3 +3,4 @@
  * This makes it so that it never actually gets used in any test...whatsoever
  */
 module.exports = jest.fn();
+module.exports.enableThreadSafety = jest.fn();


### PR DESCRIPTION
See https://github.com/nodegit/nodegit/pull/836

May help with the segfaults we've been seeing.