### PR TITLE
Wait a bit longer before removing stale containers

### DIFF
--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -16,7 +16,7 @@ describe('api', () => {
 
 		const EXPIRED_TIME = Date.now() - CONTAINER_EXPIRY_TIME - 1;
 		const GOOD_TIME = Date.now() - CONTAINER_EXPIRY_TIME + 1;
-		const images = [{ Image: getImageName('1') }, { Image: getImageName('2') }];
+		const images = [{ Image: getImageName('1'), Id: 1 }, { Image: getImageName('2'), Id: 2 }];
 
 		test('returns nothing for empty list of containers', () => {
 			expect(getExpiredContainers([], () => 0)).toEqual([]);


### PR DESCRIPTION
When the app restarts, we lose all of the container access information. Before, we would look for stale containers and remove them when the server spun up. Part of the staleness calculation is how long ago a container was created, but e2e tests can often take more than the window allotted, so we would sometimes spin down an active container.

Instead of looking for stale containers immediately, wait a couple minutes to see if any active containers get accesses. Then start the work of removing stale containers.

Last, docker list containers api seems to be occassionally returning the same container more than once. Add a uniqBy filter when pulling the image list.