### PR TITLE
Move the loop running to index

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -327,7 +327,7 @@ export function getExpiredContainers(containers: Array<ContainerInfo>, getAccess
 }
 
 // stop any container that hasn't been accessed within ten minutes
-async function cleanupExpiredContainers() {
+export async function cleanupExpiredContainers() {
 	l.log( 'looking for expired containers' );
 	const containers = Array.from( await docker.listContainers( { all: true } ) );
 	const expiredContainers = getExpiredContainers(containers, getCommitAccessTime);
@@ -370,20 +370,4 @@ export async function proxyRequestToHash(req: any, res: any) {
 	});
 }
 
-if (process.env.NODE_ENV !== 'test') {
-	const loop = ( f: Function, delay: number ) => {
-		const run = async () => ( await f(), setTimeout( run, delay ) );
 
-		run();
-	}
-
-	loop( refreshLocalImages, 5 * ONE_SECOND );
-	loop( refreshRunningContainers, 5 * ONE_SECOND );
-	loop( refreshRemoteBranches, ONE_MINUTE );
-	// Wait a bit before starting the expired container cleanup.
-	// This gives us some time to accumulate accesses to existing containers across app restarts
-	setTimeout( 
-		() => loop( cleanupExpiredContainers, ONE_MINUTE ), 
-		2 * ONE_MINUTE 
-	);
-}

--- a/src/api.ts
+++ b/src/api.ts
@@ -310,7 +310,7 @@ export function getCommitAccessTime( hash: CommitHash ): number | undefined {
  * Expired means have not been accessed in EXPIRED_DURATION
  */
 export function getExpiredContainers(containers: Array<ContainerInfo>, getAccessTime: Function) {
-	return _.uniqBy( containers.filter((container: ContainerInfo) => {
+	return containers.filter((container: ContainerInfo) => {
 		const imageName: string = container.Image;
 
 		// exclude container if it wasnt created by this app
@@ -323,7 +323,7 @@ export function getExpiredContainers(containers: Array<ContainerInfo>, getAccess
 
 		return createdAgo > CONTAINER_EXPIRY_TIME &&
 			( _.isUndefined(lastAccessed) || Date.now() - lastAccessed > CONTAINER_EXPIRY_TIME );
-	} ), ci => ci.Id );
+	} );
 }
 
 // stop any container that hasn't been accessed within ten minutes


### PR DESCRIPTION
Prior it was in api, which is a requirement of logger. Daemon pulls in
logger, which was double initializing the loops, once in the daemon
process and once in the master.

Moving the initialzation to index prevents the duplication.