### PR TITLE
Add subdomain support to dserve

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ Here is an example flow of what happens when requesting a never-requested-before
 
 **middlewares.ts** this file contains all of the middlewares that dserve uses.
 
-  1. _determineCommitHash_: every request to dserve needs to be associated with a commit hash or else it cannot be fulfilled.  this middleware will attach a `commitHash` to the express request based on: session, and query params (branch or hash).
-  2. _session_: standard session middleware so that each request doesn't need to specify a hash with a query param.
+  1. _redirectHashFromQueryStringToSubdomain_: This middleware will look for a branch or hash in the query string and redirect to a corresponding subdomain matching the commit hash.
+  2. _determineCommitHash_: Every request to dserve needs to be associated with a commit hash or else it cannot be fulfilled.  this middleware will attach a `commitHash` to the express request based on the subdomain.
+  3. _session_: Standard session middleware so that each request doesn't need to specify a hash with a query param.
 
 **api.ts**: Contains all of the code that interfaces with external things like the fs, docker, or github.  there are two kinds of entities that exist in this file, those that periodically update data and the other is helper functions for things that need to be done on-demand.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import {
   getLocalImages,
   getBranchHashes
 } from "./api";
+
 import {
   isBuildInProgress,
   buildImageForHash,
@@ -28,13 +29,20 @@ import {
   addToBuildQueue,
   cleanupBuildDir
 } from "./builder";
-import { determineCommitHash, session } from "./middlewares";
+
+import {
+  redirectHashFromQueryStringToSubdomain,
+  determineCommitHash,
+  session
+} from "./middlewares";
+
 import renderApp from "./app/index";
 import renderLocalImages from "./app/local-images";
 import renderLog from "./app/log";
 import renderDebug from "./app/debug";
 import { l } from "./logger";
 import { Writable } from "stream";
+
 import {
   refreshLocalImages,
   refreshRemoteBranches,
@@ -125,7 +133,9 @@ calypsoServer.get(
   }
 );
 
+calypsoServer.use(redirectHashFromQueryStringToSubdomain);
 calypsoServer.use(determineCommitHash);
+
 calypsoServer.get("/status", async (req: any, res: any) => {
   const commitHash = req.session.commitHash;
   let status;

--- a/src/middlewares.ts
+++ b/src/middlewares.ts
@@ -37,7 +37,7 @@ function getCommitHashFromSubdomain(host: string) {
   return hash;
 }
 
-export async function redirectHashFromQueryStringToSubdomain(
+export function redirectHashFromQueryStringToSubdomain(
   req: any,
   res: any,
   next: any
@@ -56,7 +56,7 @@ export async function redirectHashFromQueryStringToSubdomain(
   res.end();
 }
 
-export async function determineCommitHash(req: any, res: any, next: any) {
+export function determineCommitHash(req: any, res: any, next: any) {
   const isHashInSession = !!req.session.commitHash;
   const subdomainCommitHash = getCommitHashFromSubdomain(req.headers.host);
 

--- a/src/middlewares.ts
+++ b/src/middlewares.ts
@@ -44,18 +44,12 @@ export async function redirectHashFromQueryStringToSubdomain(
 ) {
   const isHashSpecified = req.query && (req.query.hash || req.query.branch);
 
-  let commitHash;
-
   if (!isHashSpecified) {
     next();
     return;
   }
 
-  if (req.query.hash) {
-    commitHash = req.query.hash;
-  } else if (req.query.branch) {
-    commitHash = getCommitHashForBranch(req.query.branch);
-  }
+  const commitHash = req.query.hash || getCommitHashForBranch(req.query.branch);
 
   res.redirect(assembleSubdomainUrlForHash(req, commitHash));
 

--- a/src/middlewares.ts
+++ b/src/middlewares.ts
@@ -1,17 +1,10 @@
 // external
-import * as express from "express";
-import * as httpProxy from "http-proxy";
 import * as expressSession from "express-session";
-import * as _ from "lodash";
-import * as striptags from "striptags";
 
 // internal
 import {
   getCommitHashForBranch,
-  hasHashLocally,
   CommitHash,
-  NotFound,
-  getPortForContainer,
   touchCommit
 } from "./api";
 

--- a/src/middlewares.ts
+++ b/src/middlewares.ts
@@ -1,107 +1,108 @@
 // external
-import * as express from 'express';
-import * as httpProxy from 'http-proxy';
-import * as expressSession from 'express-session';
-import * as _ from 'lodash';
-import * as striptags from 'striptags';
+import * as express from "express";
+import * as httpProxy from "http-proxy";
+import * as expressSession from "express-session";
+import * as _ from "lodash";
+import * as striptags from "striptags";
 
 // internal
 import {
-	getCommitHashForBranch,
-	hasHashLocally,
-	CommitHash,
-	NotFound,
-	getPortForContainer,
-	touchCommit,
-} from './api';
+  getCommitHashForBranch,
+  hasHashLocally,
+  CommitHash,
+  NotFound,
+  getPortForContainer,
+  touchCommit
+} from "./api";
 
 function assembleSubdomainUrlForHash(req: any, commitHash: string) {
-    const protocol = (req.secure ? 'https' : 'http');
+  const protocol = req.secure ? "https" : "http";
 
-    return protocol + '://hash-' + commitHash + '.' + stripCommitHashSubdomainFromHost(req.headers.host);
+  return (
+    protocol +
+    "://hash-" +
+    commitHash +
+    "." +
+    stripCommitHashSubdomainFromHost(req.headers.host)
+  );
 }
 
 function stripCommitHashSubdomainFromHost(host: string) {
-    let segments = host.split('.'),
-        commitHashIndex = null;
+  let segments = host.split("."),
+    commitHashIndex = null;
 
-    for (let i = 0; i < segments.length; i += 1) {
-        if (0 === segments[i].indexOf('hash-')) {
-            commitHashIndex = i;
-            break;
-        }
+  for (let i = 0; i < segments.length; i += 1) {
+    if (0 === segments[i].indexOf("hash-")) {
+      commitHashIndex = i;
+      break;
     }
+  }
 
-    if (null === commitHashIndex) {
-        return host;
-    }
+  if (null === commitHashIndex) {
+    return host;
+  }
 
-    return segments.slice(commitHashIndex + 1).join('.');
+  return segments.slice(commitHashIndex + 1).join(".");
 }
 
 function getCommitHashFromSubdomain(req: any) {
-    const commitHash = _.find(
-        req.headers.host.split('.'),
-        function (hostSegment) {
-            return 0 === hostSegment.indexOf('hash-');
-        }
-    );
+  const commitHash = _.find(req.headers.host.split("."), function(hostSegment) {
+    return 0 === hostSegment.indexOf("hash-");
+  });
 
-    return commitHash.replace(/^hash-/, '');
+  return commitHash.replace(/^hash-/, "");
 }
 
-export async function redirectHashFromQueryStringToSubdomain(req: any, res: any, next: any) {
-    const isHashSpecified = req.query && (req.query.hash || req.query.branch);
+export async function redirectHashFromQueryStringToSubdomain(
+  req: any,
+  res: any,
+  next: any
+) {
+  const isHashSpecified = req.query && (req.query.hash || req.query.branch);
 
-    let commitHash;
+  let commitHash;
 
-    if (!isHashSpecified) {
-        next();
-        return;
-    }
+  if (!isHashSpecified) {
+    next();
+    return;
+  }
 
-    if (req.query.hash) {
-		commitHash = req.query.hash;
-	} else if (req.query.branch) {
-		commitHash = getCommitHashForBranch(req.query.branch);
-    }
+  if (req.query.hash) {
+    commitHash = req.query.hash;
+  } else if (req.query.branch) {
+    commitHash = getCommitHashForBranch(req.query.branch);
+  }
 
-    res.writeHead(
-        302,
-        {
-            'Location': assembleSubdomainUrlForHash(req, commitHash)
-        }
-    );
+  res.redirect(assembleSubdomainUrlForHash(req, commitHash));
 
-    res.end();
+  res.end();
 }
 
 export async function determineCommitHash(req: any, res: any, next: any) {
-    const isHashInSession     = !!req.session.commitHash;
-    const subdomainCommitHash = getCommitHashFromSubdomain(req);
+  const isHashInSession = !!req.session.commitHash;
+  const subdomainCommitHash = getCommitHashFromSubdomain(req);
 
-	if (isHashInSession && !subdomainCommitHash) {
-		next();
-		return;
-	}
+  if (isHashInSession && !subdomainCommitHash) {
+    next();
+    return;
+  }
 
-    if (!subdomainCommitHash) {
-        // @todo Render a nicer page here.
-		res.send('Please specify a branch to load');
-		return;
-	}
+  if (!subdomainCommitHash) {
+    // @todo Render a nicer page here.
+    res.send("Please specify a branch to load");
+    return;
+  }
 
-	req.session.commitHash = subdomainCommitHash;
+  req.session.commitHash = subdomainCommitHash;
 
-    touchCommit(subdomainCommitHash);
+  touchCommit(subdomainCommitHash);
 
-	next();
+  next();
 }
 
 export const session = expressSession({
-	secret: 'keyboard cat',
-	cookie: {},
-	resave: false,
-	saveUninitialized: true,
+  secret: "keyboard cat",
+  cookie: {},
+  resave: false,
+  saveUninitialized: true
 });
-

--- a/src/middlewares.ts
+++ b/src/middlewares.ts
@@ -17,7 +17,7 @@ import {
 
 const hashPattern = /(?:^|.*?\.)hash-([a-f0-9]+)\./;
 
-function assembleSubdomainUrlForHash(req: any, commitHash: string) {
+function assembleSubdomainUrlForHash(req: any, commitHash: CommitHash) {
   const protocol = req.secure ? "https" : "http";
 
   return (


### PR DESCRIPTION
Current versions of dserve use a single domain for all commits and branches.  This can allow cross-contamination of client-side resources like cookies, localStorage and assets cached by service workers across different builds/images.

By instead using subdomains, we can leverage the browser's built-in mechanisms for isolating domains to ensure that our builds don't interact in unpredictable ways.

The new middleware in this commit maintains support for "hash" and "branch" query string parameters.  When present, those parameters will trigger a redirect to [commit-hash].[host-name].

The next middleware in the processing chain then grabs the commit hash from the subdomain and stores it in the session, where the rest of dserve expects to find it.

## Testing 

To test locally, you'll need hosts file entries for whichever commits you want to test:

`127.0.0.1 [commit-hash].calypso.localhost`

When accessing a branch or commit hash via query string parameter, you'll be redirected to the equivalent subdomain.  Navigating to `calypso.localhost:3000?hash=b84096f22f59c307620d4978bc48ea47da65d5a6`, for example, will redirect you to `b84096f22f59c307620d4978bc48ea47da65d5a6.calypso.localhost:3000`.
