### PR TITLE
include the original path in the redirect

### DIFF
--- a/src/middlewares.ts
+++ b/src/middlewares.ts
@@ -18,7 +18,8 @@ function assembleSubdomainUrlForHash(req: any, commitHash: CommitHash) {
     "://hash-" +
     commitHash +
     "." +
-    stripCommitHashSubdomainFromHost(req.headers.host)
+    stripCommitHashSubdomainFromHost(req.headers.host) +
+    req.path
   );
 }
 


### PR DESCRIPTION
makes a request for `/log-in` end up on `hash-1234/log-in`