### PR TITLE
Refresh branches when asked for an unknown branch name

### DIFF
--- a/src/middlewares.ts
+++ b/src/middlewares.ts
@@ -4,9 +4,12 @@ import * as expressSession from "express-session";
 // internal
 import {
   getCommitHashForBranch,
+  refreshRemoteBranches,
   CommitHash,
-  touchCommit
+  touchCommit,
+  ONE_MINUTE
 } from "./api";
+import { RSA_NO_PADDING } from "constants";
 
 const hashPattern = /(?:^|.*?\.)hash-([a-f0-9]+)\./;
 
@@ -41,7 +44,8 @@ function getCommitHashFromSubdomain(host: string) {
 export function redirectHashFromQueryStringToSubdomain(
   req: any,
   res: any,
-  next: any
+  next: any,
+  retry: boolean = true
 ) {
   const isHashSpecified = req.query && (req.query.hash || req.query.branch);
 
@@ -51,6 +55,22 @@ export function redirectHashFromQueryStringToSubdomain(
   }
 
   const commitHash = req.query.hash || getCommitHashForBranch(req.query.branch);
+
+  const sendError = () => {
+    res.send('could not find a hash for that branch');
+    res.end();
+  }
+
+  if (!commitHash) {
+    // could not find a hash for the branch... refresh the remotes and try again
+    if (retry) {
+      refreshRemoteBranches().then(() => {
+        redirectHashFromQueryStringToSubdomain(req, res, next, false);
+      }).catch(sendError);
+      return;
+    }
+    sendError();
+  }
 
   res.redirect(assembleSubdomainUrlForHash(req, commitHash));
 

--- a/src/middlewares.ts
+++ b/src/middlewares.ts
@@ -45,7 +45,7 @@ export function redirectHashFromQueryStringToSubdomain(
   req: any,
   res: any,
   next: any,
-  retry: boolean = true
+  retry: number = 2
 ) {
   const isHashSpecified = req.query && (req.query.hash || req.query.branch);
 
@@ -63,9 +63,9 @@ export function redirectHashFromQueryStringToSubdomain(
 
   if (!commitHash) {
     // could not find a hash for the branch... refresh the remotes and try again
-    if (retry) {
+    if (retry > 0) {
       refreshRemoteBranches().then(() => {
-        redirectHashFromQueryStringToSubdomain(req, res, next, false);
+        redirectHashFromQueryStringToSubdomain(req, res, next, retry - 1);
       }).catch(sendError);
       return;
     }


### PR DESCRIPTION
Also prevent concurrent refresh requests.

Future: Consider retrying twice instead of once to catch cases where the refresh was triggered during a refresh and the first refresh was too early to pull the new branch. Should be a pretty minor timing issue.

Testing:
This is a timing trap so you have to be quick.
* Find a branch name in a PR in wp-calypso
* Get ready to request that url with curl (`curl -I https://localhost:3000/?branch=your/branch`)
* Start dserve
* The moment dserve comes up, fire off the curl request
* The response should hold until we have a fresh set of branch names and come back with a valid `Location` header

On master, the response would come back immediately with a url to `hash-undefined.localhost:3000/...`