### PR TITLE
Middleware: Pass non-branch query parameters on redirect

### DIFF
--- a/src/middlewares.ts
+++ b/src/middlewares.ts
@@ -16,9 +16,9 @@ const hashPattern = /(?:^|.*?\.)hash-([a-f0-9]+)\./;
 function assembleSubdomainUrlForHash(req: any, commitHash: CommitHash) {
   const protocol = req.secure || req.headers.host.indexOf( 'calypso.live' ) > -1 ? "https" : "http";
 
-  const query = 
+  const query =
     Object.keys( req.query )
-    .reduce( ( q, key ) => key === 'branch' ? q : q.concat( `${ key }=${ q[ key as keyof {} ] }` ), [] )
+    .reduce( ( q, key ) => key === 'branch' ? q : q.concat( `${ encodeURIComponent( key ) }=${ encodeURIComponent( q[ key as keyof {} ] ) }` ), [] )
     .join( '&' );
 
   return (

--- a/src/middlewares.ts
+++ b/src/middlewares.ts
@@ -16,13 +16,19 @@ const hashPattern = /(?:^|.*?\.)hash-([a-f0-9]+)\./;
 function assembleSubdomainUrlForHash(req: any, commitHash: CommitHash) {
   const protocol = req.secure || req.headers.host.indexOf( 'calypso.live' ) > -1 ? "https" : "http";
 
+  const query = 
+    Object.keys( req.query )
+    .reduce( ( q, key ) => key === 'branch' ? q : q.concat( `${ key }=${ q[ key as keyof {} ] }` ), [] )
+    .join( '&' );
+
   return (
     protocol +
     "://hash-" +
     commitHash +
     "." +
     stripCommitHashSubdomainFromHost(req.headers.host) +
-    req.path
+    req.path +
+    query ? `?${ query }` : ''
   );
 }
 

--- a/src/middlewares.ts
+++ b/src/middlewares.ts
@@ -18,7 +18,10 @@ function assembleSubdomainUrlForHash(req: any, commitHash: CommitHash) {
 
   const query =
     Object.keys( req.query )
-    .reduce( ( q, key ) => key === 'branch' ? q : q.concat( `${ encodeURIComponent( key ) }=${ encodeURIComponent( q[ key as keyof {} ] ) }` ), [] )
+    .reduce(
+      ( q, key ) => key === 'branch' ? q : q.concat( `${ encodeURIComponent( key ) }=${ encodeURIComponent( q[ key as keyof {} ] ) }` ),
+      []
+    )
     .join( '&' );
 
   return (


### PR DESCRIPTION
Resolves #79

When we remap a given URL from `calypso.live?branch=...` to the
"subdomain" URL we have been stripping away the entire query string when
redirecting the browser. This causes problems when we want to pass flags
to Calypso or otherwise send query args.

In this change we're appending the existing query string without the
branch name specified so that we can pass everything else through.

No query arg named `branch` will pass through though.

**Testing**

I need help testing this. I think the local environment is different than the
production one with subdomains and so I don't know if I can get this flow
fully tested locally.