### PR TITLE
Ensure build-arg is type string

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -120,7 +120,7 @@ export async function buildImageForHash(commitHash: CommitHash): Promise<void> {
 			nocache: false,
 			buildargs: {
 				commit_sha: commitHash,
-				workers: SINGLE_BUILD_CONCURRENCY,
+				workers: String( SINGLE_BUILD_CONCURRENCY ),
 			},
 		});
 	} catch (err) {


### PR DESCRIPTION
#82 introduced a bug. This should fix errors like:

```
err: {
  "message": "(HTTP code 500) server error - json: cannot unmarshal number into Go value of type string ",
  "name": "Error",
  "stack": "Error: (HTTP code 500) server error - json: cannot unmarshal number into Go value of type string \n    at /home/dserve/src/node_modules/docker-modem/lib/modem.js:254:17\n    at IncomingMessage.<anonymous> (/home/dserve/src/node_modules/docker-modem/lib/modem.js:281:9)\n    at IncomingMessage.emit (events.js:187:15)\n    at endReadableNT (_stream_readable.js:1094:12)\n    at process._tickCallback (internal/process/next_tick.js:63:19)"
}
```