### PR TITLE
Revert "Middleware: Pass non-branch query parameters on redirect"

### DIFF
--- a/src/middlewares.ts
+++ b/src/middlewares.ts
@@ -16,22 +16,13 @@ const hashPattern = /(?:^|.*?\.)hash-([a-f0-9]+)\./;
 function assembleSubdomainUrlForHash(req: any, commitHash: CommitHash) {
   const protocol = req.secure || req.headers.host.indexOf( 'calypso.live' ) > -1 ? "https" : "http";
 
-  const query =
-    Object.keys( req.query )
-    .reduce(
-      ( q, key ) => key === 'branch' ? q : q.concat( `${ encodeURIComponent( key ) }=${ encodeURIComponent( q[ key as keyof {} ] ) }` ),
-      []
-    )
-    .join( '&' );
-
   return (
     protocol +
     "://hash-" +
     commitHash +
     "." +
     stripCommitHashSubdomainFromHost(req.headers.host) +
-    req.path +
-    query ? `?${ query }` : ''
+    req.path
   );
 }
 


### PR DESCRIPTION
Reverts Automattic/dserve#81

#81 did not work as expected. Redirections were happening as follows without ever booting a branch or arriving at desired sha URLs:

`/?branch=master` -> `/?`
`/?branch=master&flags=jetpack/checklist` -> `/?flags=undefined`