### PR TITLE
Update CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,17 +15,20 @@ jobs:
 
       # Download and cache dependencies
       - restore_cache:
-          keys:
-          - v1-dependencies-{{ checksum "package.json" }}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
+          key: v2-dependencies-{{ checksum "yarn.lock" }}
 
-      - run: yarn install
+      - run:
+          command: |
+            name: Install node dependencies
+            command: |
+              if [ ! -d node_modules ]; then
+                yarn
+              fi
 
       - save_cache:
+          key: v2-dependencies-{{ checksum "yarn.lock" }}
           paths:
             - node_modules
-          key: v1-dependencies-{{ checksum "package.json" }}
 
       # run tests!
       - run: yarn test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: node:8.0
+      - image: circleci/node:10
 
     working_directory: ~/repo
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,9 @@ jobs:
           paths:
             - node_modules
 
+      # Ensure TypeScript builds
+      - run: yarn run build-ts
+
       # run tests!
       - run: yarn test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,12 +18,11 @@ jobs:
           key: v2-dependencies-{{ checksum "yarn.lock" }}
 
       - run:
+          name: Install node dependencies
           command: |
-            name: Install node dependencies
-            command: |
-              if [ ! -d node_modules ]; then
-                yarn
-              fi
+            if [ ! -d node_modules ]; then
+              yarn
+            fi
 
       - save_cache:
           key: v2-dependencies-{{ checksum "yarn.lock" }}


### PR DESCRIPTION
- Use circleci node image
- Use yarn.lock to save/restore node_modules cache
- Skip install on node_modules cache hit
- Include `build-ts` as part of CI