### PR TITLE
GC the git repo after updating branches

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -18,6 +18,7 @@ import { l, getLoggerForBuild, closeLogger } from './logger';
 import { getBuildDir } from './builder';
 import { setInterval } from 'timers';
 import { stat } from 'fs';
+import { exec } from 'child_process';
 
 type APIState = {
 	accesses: Map<CommitHash, number>;
@@ -272,6 +273,17 @@ async function getRemoteBranches(): Promise<Map<string, string>> {
 		} ) );
 
 		repo.free();
+		// gc the repo
+		l.log( {}, 'git gc start' );
+		try {
+			await promisify( exec )( 'git gc', {
+				cwd: calypsoDir
+			});
+			l.log( {}, 'git gc complete' );
+		} catch ( err ) {
+			l.error( { err }, 'git gc failed' );
+		}
+
 		return branchToCommitHashMap;
 	} catch (err) {
 		l.error({ err, repository: config.repo.project }, 'Error creating branchName --> commitSha map');


### PR DESCRIPTION
libgit2 doesn't support gc at all, so we have to do it on the side.

We only write to the main branch tracking repo in one place, in refreshBranches, so it's the logical place to also do the GC.

see https://github.com/libgit2/libgit2/issues/2758