### PR TITLE
Fix: Loops ran too often due

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -20,6 +20,8 @@ import { setInterval } from 'timers';
 import { stat } from 'fs';
 import { exec } from 'child_process';
 
+import { CONTAINER_EXPIRY_TIME } from './constants';
+
 type APIState = {
 	accesses: Map< CommitHash, number >;
 	branchHashes: Map< CommitHash, BranchName >;
@@ -47,11 +49,6 @@ export type BranchName = string;
 export type PortNumber = number;
 export type ImageStatus = 'NoImage' | 'Inactive' | PortNumber;
 
-export const ONE_SECOND = 1000;
-export const ONE_MINUTE = 60 * ONE_SECOND;
-export const FIVE_MINUTES = 5 * ONE_MINUTE;
-export const TEN_MINUTES = 10 * ONE_MINUTE;
-export const CONTAINER_EXPIRY_TIME = 20 * ONE_MINUTE;
 
 export const getImageName = ( hash: CommitHash ) => `${ config.build.tagPrefix }:${ hash }`;
 export const extractCommitFromImage = ( imageName: string ): CommitHash =>

--- a/src/app/debug.tsx
+++ b/src/app/debug.tsx
@@ -3,7 +3,7 @@ import * as ReactDOMServer from 'react-dom/server';
 import * as Dockerode from 'dockerode';
 import * as os from 'os';
 
-import { ONE_MINUTE } from '../api';
+import { ONE_MINUTE } from '../constants';
 import { Shell } from './app-shell';
 import { promiseRejections } from '../index';
 import { humanSize, humanTime, percent, round } from './util';

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as ReactDOMServer from 'react-dom/server';
-import { ONE_SECOND } from '../api';
+import { ONE_SECOND } from '../constants';
 
 import { Shell } from './app-shell';
 import stripAnsi = require('strip-ansi');

--- a/src/app/local-images.tsx
+++ b/src/app/local-images.tsx
@@ -5,7 +5,8 @@ import { config } from '../config';
 
 import { Shell } from './app-shell';
 import { humanSize, humanTime } from './util';
-import { ONE_MINUTE, ONE_SECOND, BranchName, CommitHash } from '../api';
+import { BranchName, CommitHash } from '../api';
+import { ONE_MINUTE, ONE_SECOND } from '../constants';
 
 const LocalImages = ( {
 	branchHashes,

--- a/src/app/log.tsx
+++ b/src/app/log.tsx
@@ -3,7 +3,7 @@ import * as ReactDOMServer from 'react-dom/server';
 
 import { Shell } from './app-shell';
 import { errorClass, humanTime } from './util';
-import { ONE_MINUTE } from '../api';
+import { ONE_MINUTE } from '../constants';
 import LogDetails from './log-details';
 
 

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -7,9 +7,6 @@ import { Readable } from 'stream';
 
 import {
 	CommitHash,
-	ONE_SECOND,
-	ONE_MINUTE,
-	FIVE_MINUTES,
 	getImageName,
 	docker,
 	BranchName,
@@ -17,6 +14,9 @@ import {
 } from './api';
 import { config } from './config';
 import { closeLogger, l, getLoggerForBuild } from './logger';
+import { 	ONE_SECOND,
+	ONE_MINUTE,
+	FIVE_MINUTES } from './constants';
 
 // hidden method in nodegit that turns on thread safety
 // see https://github.com/nodegit/nodegit/pull/836
@@ -182,12 +182,18 @@ export async function buildImageForHash( commitHash: CommitHash ): Promise< void
 // Background tasks
 
 const loop = ( f: Function, delay: number ) => {
-	const run = () => ( f(), setTimeout( run, delay ) );
+	console.log( 'setting up a loop with %o and %d', f, delay );
+	const run = () => {
+		f();
+		//console.log( 'running loop with %o and %d', f, delay );
+		setTimeout( run, delay ); 
+	};
 
 	run();
 };
 
 function warnOnQueueBuildup() {
+	console.log( 'hi' );
 	if ( buildQueue.length > MAX_CONCURRENT_BUILDS ) {
 		l.log(
 			{ buildQueue },

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -182,7 +182,6 @@ export async function buildImageForHash( commitHash: CommitHash ): Promise< void
 // Background tasks
 
 const loop = ( f: Function, delay: number ) => {
-	console.log( 'setting up a loop with %o and %d', f, delay );
 	const run = () => {
 		f();
 		//console.log( 'running loop with %o and %d', f, delay );
@@ -193,7 +192,6 @@ const loop = ( f: Function, delay: number ) => {
 };
 
 function warnOnQueueBuildup() {
-	console.log( 'hi' );
 	if ( buildQueue.length > MAX_CONCURRENT_BUILDS ) {
 		l.log(
 			{ buildQueue },

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,5 @@
+export const ONE_SECOND = 1000;
+export const ONE_MINUTE = 60 * ONE_SECOND;
+export const FIVE_MINUTES = 5 * ONE_MINUTE;
+export const TEN_MINUTES = 10 * ONE_MINUTE;
+export const CONTAINER_EXPIRY_TIME = 20 * ONE_MINUTE;

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,8 +7,6 @@ import { exec } from 'child_process';
 
 // internal
 import {
-	ONE_MINUTE,
-	ONE_SECOND,
 	getCommitHashForBranch,
 	getKnownBranches,
 	hasHashLocally,
@@ -22,6 +20,9 @@ import {
 	getLocalImages,
 	getBranchHashes,
 } from './api';
+
+import { 	ONE_MINUTE,
+	ONE_SECOND, } from './constants';
 
 import {
 	isBuildInProgress,

--- a/src/middlewares.ts
+++ b/src/middlewares.ts
@@ -8,9 +8,7 @@ import {
 	refreshRemoteBranches,
 	CommitHash,
 	touchCommit,
-	ONE_MINUTE,
 } from './api';
-import { RSA_NO_PADDING } from 'constants';
 
 const hashPattern = /(?:^|.*?\.)hash-([a-f0-9]+)\./;
 

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -2,9 +2,10 @@ import {
 	getCommitAccessTime,
 	touchCommit,
 	getExpiredContainers,
-	CONTAINER_EXPIRY_TIME,
 	getImageName,
 } from '../src/api';
+
+import { CONTAINER_EXPIRY_TIME } from '../src/constants';
 
 describe( 'api', () => {
 	describe( 'getExpiredContainers', () => {


### PR DESCRIPTION
Loops initiated in builder.ts were running as fast as possible because the constants that spec the delay were not initialized when the loops were set up. The constants were not initialized because of a cyclic dependency between builder and api were they were defined. When a cyclic dependency is present, the initialization order is undefined and exported variables may not yet have a value.