### PR TITLE
Rework logger to use a memory stream instead of unreliable disk

### DIFF
--- a/src/app/log.tsx
+++ b/src/app/log.tsx
@@ -50,27 +50,14 @@ const Log = ( { log, startedServerAt }: RenderContext ) => (
 		/>
 		<ol className="dserve-log-lines">
 			{ log
-				.split( '\n' )
-				.filter( l => l.length > 0 )
 				.reverse()
-				.map( ( line, i ) => {
-					let data;
-					try {
-						data = JSON.parse( line );
-					} catch ( e ) {
-						return (
-							<li className="dserve-log-line" key={ `${ i }-${ line }` }>
-								Unparseable log item - »<pre>{ line }</pre>«
-							</li>
-						);
-					}
-
+				.map( ( data, i ) => {
 					const at = Date.parse( data.time );
 
 					return (
 						<li
 							className={ `dserve-log-line ${ errorClass( data.level ) }` }
-							key={ `${ i }-${ line }` }
+							key={ `${ i }` }
 						>
 							<time
 								dateTime={ new Date( at ).toISOString() }
@@ -90,7 +77,7 @@ const Log = ( { log, startedServerAt }: RenderContext ) => (
 	</Shell>
 );
 
-type RenderContext = { log: string; startedServerAt: Date };
+type RenderContext = { log: any[]; startedServerAt: Date };
 export default function renderLog( renderContext: RenderContext ) {
 	return ReactDOMServer.renderToStaticMarkup( <Log { ...renderContext } /> );
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ import renderApp from './app/index';
 import renderLocalImages from './app/local-images';
 import renderLog from './app/log';
 import renderDebug from './app/debug';
-import { l } from './logger';
+import { l, ringbuffer } from './logger';
 import { Writable } from 'stream';
 
 import {
@@ -90,15 +90,9 @@ logRejections();
 // get application log for debugging
 calypsoServer.get( '/log', ( req: express.Request, res: express.Response ) => {
 	//const appLog = fs.readFileSync("./logs/log.txt", "utf-8"); // todo change back from l
-	exec( 'tail -n 500 ./logs/log.txt', { maxBuffer: 5000 * 1024 }, ( err, stdout ) => {
-		if ( err ) {
-			res.send( 'error reading log file. ' + err );
-			return;
-		}
 		isBrowser( req )
-			? res.send( renderLog( { log: stdout, startedServerAt } ) )
-			: res.send( stdout );
-	} );
+			? res.send( renderLog( { log: ringbuffer.records, startedServerAt } ) )
+			: res.send( ringbuffer.records );
 } );
 
 calypsoServer.get( '/localimages', ( req: express.Request, res: express.Response ) => {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -6,6 +6,8 @@ import { CommitHash, getImageName } from './api';
 import { getLogPath } from './builder';
 import { config } from './config';
 
+export const ringbuffer = new bunyan.RingBuffer({ limit: 1000 });
+
 const dserveLogger = bunyan.createLogger( {
 	name: 'dserve',
 	streams: [
@@ -14,6 +16,11 @@ const dserveLogger = bunyan.createLogger( {
 			path: './logs/log.txt',
 			period: '1d',
 			count: 7,
+		},
+		{
+			level: bunyan.DEBUG,
+			type: 'raw',
+			stream: ringbuffer
 		},
 		{
 			stream: process.stdout,


### PR DESCRIPTION
We've had problems with the rotating file logger not actually writing to disk after rotating. Instead, write recent logs to a ring buffer and read the log display from there.