### PR TITLE
Fix bad reverse on logging

### DIFF
--- a/src/app/log.tsx
+++ b/src/app/log.tsx
@@ -6,7 +6,6 @@ import { errorClass, humanTime } from './util';
 import { ONE_MINUTE } from '../constants';
 import LogDetails from './log-details';
 
-
 const Log = ( { log, startedServerAt }: RenderContext ) => (
 	<Shell refreshInterval={ ONE_MINUTE } startedServerAt={ startedServerAt }>
 		<style
@@ -50,15 +49,11 @@ const Log = ( { log, startedServerAt }: RenderContext ) => (
 		/>
 		<ol className="dserve-log-lines">
 			{ log
-				.reverse()
 				.map( ( data, i ) => {
 					const at = Date.parse( data.time );
 
 					return (
-						<li
-							className={ `dserve-log-line ${ errorClass( data.level ) }` }
-							key={ `${ i }` }
-						>
+						<li className={ `dserve-log-line ${ errorClass( data.level ) }` } key={ `${ i }` }>
 							<time
 								dateTime={ new Date( at ).toISOString() }
 								title={ new Date( at ).toLocaleTimeString( undefined, {
@@ -72,7 +67,8 @@ const Log = ( { log, startedServerAt }: RenderContext ) => (
 							<LogDetails data={ data } />
 						</li>
 					);
-				} ) }
+				} )
+				.reverse() }
 		</ol>
 	</Shell>
 );

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,8 +21,7 @@ import {
 	getBranchHashes,
 } from './api';
 
-import { 	ONE_MINUTE,
-	ONE_SECOND, } from './constants';
+import { ONE_MINUTE, ONE_SECOND } from './constants';
 
 import {
 	isBuildInProgress,
@@ -89,10 +88,9 @@ logRejections();
 
 // get application log for debugging
 calypsoServer.get( '/log', ( req: express.Request, res: express.Response ) => {
-	//const appLog = fs.readFileSync("./logs/log.txt", "utf-8"); // todo change back from l
-		isBrowser( req )
-			? res.send( renderLog( { log: ringbuffer.records, startedServerAt } ) )
-			: res.send( ringbuffer.records );
+	isBrowser( req )
+		? res.send( renderLog( { log: ringbuffer.records, startedServerAt } ) )
+		: res.send( ringbuffer.records );
 } );
 
 calypsoServer.get( '/localimages', ( req: express.Request, res: express.Response ) => {


### PR DESCRIPTION
We were reversing the actual array that holds the ringbuffer, so every refresh would reverse the order of the recent log.