### PR TITLE
Release the pendingHash lock when we see total build failure

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -145,6 +145,8 @@ export async function buildImageForHash( commitHash: CommitHash ): Promise< void
 
 	if ( ! buildStream ) {
 		l.error( { buildStream }, "Failed to build image but didn't throw an error" );
+		pendingHashes.delete( commitHash );
+		closeLogger( buildLogger as any );
 		return;
 	}
 


### PR DESCRIPTION
We clean up in onFinished, but never make it there if the build stream totally fails.