### PR TITLE
Force removal of intermediate containers when a build fails

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -126,6 +126,7 @@ export async function buildImageForHash( commitHash: CommitHash ): Promise< void
 		buildStream = await docker.buildImage( tarStream, {
 			t: imageName,
 			nocache: false,
+			forcerm: true,
 			buildargs: {
 				commit_sha: commitHash,
 				workers: String( SINGLE_BUILD_CONCURRENCY ),


### PR DESCRIPTION
This should help us clean up a lot of the containers that get left around when a build fails.

See https://docs.docker.com/engine/api/v1.37/#operation/ImageBuild