### PR TITLE
Force error reason to a string

### DIFF
--- a/src/app/debug.tsx
+++ b/src/app/debug.tsx
@@ -175,7 +175,7 @@ const Debug = ( c: RenderContext ) => {
 									>
 										{ humanTime( ts.getTime() / 1000 ) }
 									</time>{' '}
-									{ reason }
+									{ reason.toString() }
 								</li>
 							) ) }
 						</ul>


### PR DESCRIPTION
fixed debug rendering when the rejected promise reason is an object