### PR TITLE
Fix up how we determine commits from image names

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -51,8 +51,13 @@ export type ImageStatus = 'NoImage' | 'Inactive' | PortNumber;
 
 
 export const getImageName = ( hash: CommitHash ) => `${ config.build.tagPrefix }:${ hash }`;
-export const extractCommitFromImage = ( imageName: string ): CommitHash =>
-	imageName.split( ':' )[ 1 ];
+export const extractCommitFromImage = ( imageName: string ): CommitHash => {
+	const [ prefix, sha ] = imageName.split(':');
+	if ( prefix !== config.build.tagPrefix ) {
+		return null;
+	}
+	return sha;
+}
 
 /**
  * Polls the local Docker daemon to
@@ -359,6 +364,7 @@ export function touchCommit( hash: CommitHash ) {
 }
 
 export function getCommitAccessTime( hash: CommitHash ): number | undefined {
+	if ( ! hash ) { return undefined; }
 	return state.accesses.get( hash );
 }
 

--- a/src/app/debug.tsx
+++ b/src/app/debug.tsx
@@ -138,7 +138,9 @@ const Debug = ( c: RenderContext ) => {
 					{ pendingHashes.size ? (
 						<ul>
 							{ Array.from( pendingHashes ).map( hash => (
-								<li key={ hash }><a href={ `/?hash=${ hash }`}>{ hash }</a></li>
+								<li key={ hash }>
+									<a href={ `/?hash=${ hash }` }>{ hash }</a>
+								</li>
 							) ) }
 						</ul>
 					) : (
@@ -150,7 +152,9 @@ const Debug = ( c: RenderContext ) => {
 					{ buildQueue.length ? (
 						<ul>
 							{ buildQueue.map( hash => (
-								<li key={ hash }><a href={ `/?hash=${ hash }`}>{ hash }</a></li>
+								<li key={ hash }>
+									<a href={ `/?hash=${ hash }` }>{ hash }</a>
+								</li>
 							) ) }
 						</ul>
 					) : (
@@ -195,27 +199,25 @@ const Debug = ( c: RenderContext ) => {
 								<em>No running containers</em>
 							</li>
 						) : (
-							apiContainers.map( ( [ key, info ] ) => (
-								<li key={ info.Id } className={ info.State }>
-									<strong>{ info.Names }</strong> - { shortHash( info.Id ) }
-									<br />
-									Commit:{' '}
-									<a href={ `/?hash=${ extractCommitFromImage( info.Image ) }` }>
-										{ extractCommitFromImage( info.Image ) }
-									</a>
-									<br />
-									Image ID: { shortHash( info.ImageID ) }
-									<br />
-									Status: { info.Status }
-									<br />
-									Last Access:{' '}
-									{ getCommitAccessTime( extractCommitFromImage( info.Image ) )
-										? humanTime(
-												getCommitAccessTime( extractCommitFromImage( info.Image ) ) / 1000
-										  )
-										: 'never' }
-								</li>
-							) )
+							apiContainers.map( ( [ key, info ] ) => {
+								const commit = extractCommitFromImage( info.Image );
+								return (
+									<li key={ info.Id } className={ info.State }>
+										<strong>{ info.Names }</strong> - { shortHash( info.Id ) }
+										<br />
+										Commit: { commit ? <a href={ `/?hash=${ commit }` }>{ commit }</a> : 'none' }
+										<br />
+										Image ID: { shortHash( info.ImageID ) }
+										<br />
+										Status: { info.Status }
+										<br />
+										Last Access:{' '}
+										{ getCommitAccessTime( commit )
+											? humanTime( getCommitAccessTime( commit ) / 1000 )
+											: 'never' }
+									</li>
+								);
+							} )
 						) }
 					</ul>
 


### PR DESCRIPTION
Instead of blindly trusting the image name and poking for a ':', validate the prefix.

Teach debug listing to pick it up.