### PR TITLE
Reduce the number of concurrent builds to 2

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -22,7 +22,7 @@ import { 	ONE_SECOND,
 // see https://github.com/nodegit/nodegit/pull/836
 ( git as any ).enableThreadSafety();
 
-export const MAX_CONCURRENT_BUILDS = 3;
+export const MAX_CONCURRENT_BUILDS = 2;
 export const SINGLE_BUILD_CONCURRENCY = Math.max(
 	1,
 	Math.floor( os.cpus().length / MAX_CONCURRENT_BUILDS )


### PR DESCRIPTION
Seeing some builds fail (and git gc fail) when we have three builds running concurrently. Reduce to 2 and see if that improves things.

Related https://github.com/Automattic/dserve/pull/113