### PR TITLE
Wait a bit after server start before removing stale containers

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -13,7 +13,8 @@ import { l } from './logger';
 import { pendingHashes } from './builder';
 import { exec } from 'child_process';
 
-import { CONTAINER_EXPIRY_TIME } from './constants';
+import { CONTAINER_EXPIRY_TIME, START_TIME, TEN_MINUTES } from './constants';
+import Dockerode = require('dockerode');
 
 type APIState = {
 	accesses: Map< CommitHash, number >;
@@ -372,6 +373,12 @@ export function getExpiredContainers(
 	containers: Array< ContainerInfo >,
 	getAccessTime: Function
 ) {
+	// if the server is newly spun up, wait a bit before killing off running containers
+	if ( Date.now() - START_TIME < TEN_MINUTES ) {
+		return [];
+	}
+
+	// otherwise, filter off containers that are still valid
 	return containers.filter( ( container: ContainerInfo ) => {
 		const imageName: string = container.Image;
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,3 +3,5 @@ export const ONE_MINUTE = 60 * ONE_SECOND;
 export const FIVE_MINUTES = 5 * ONE_MINUTE;
 export const TEN_MINUTES = 10 * ONE_MINUTE;
 export const CONTAINER_EXPIRY_TIME = 60 * ONE_MINUTE;
+
+export const START_TIME = Date.now();

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -10,7 +10,8 @@ import { CONTAINER_EXPIRY_TIME } from '../src/constants';
 describe( 'api', () => {
 	describe( 'getExpiredContainers', () => {
 		const RealNow = Date.now;
-		Date.now = () => 10000000;
+		const fakeNow = RealNow() + 24 * 60 * 1000;
+		Date.now = () => fakeNow;
 		afterAll( () => {
 			Date.now = RealNow;
 		} );


### PR DESCRIPTION
At the moment, once the server spins up, it immediately thinks all containers that were not created in the last few minutes are stale and tries to remove them. That ends up removing containers that are currently being used for tests.

Instead, wait a few minutes to allow hits to accrue before removing stale containers.