### PR TITLE
Add some more stats.

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -14,6 +14,7 @@ import { pendingHashes } from './builder';
 import { exec } from 'child_process';
 
 import { CONTAINER_EXPIRY_TIME } from './constants';
+import { timing } from './stats';
 
 type APIState = {
 	accesses: Map< CommitHash, number >;
@@ -277,6 +278,8 @@ async function getRemoteBranches(): Promise< Map< string, string > > {
 	if ( ! repo ) {
 		l.error( 'Something went very wrong while trying to refresh branches' );
 	}
+
+	timing( 'git.refresh', Date.now() - start );
 
 	try {
 		const branchesReferences = ( await repo.getReferences( git.Reference.TYPE.OID ) ).filter(

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -179,6 +179,7 @@ export async function buildImageForHash( commitHash: CommitHash ): Promise< void
 		if ( ! err ) {
 			const buildImageTime = Date.now() - imageStart;
 			timing( 'build_image', buildImageTime );
+			increment( 'build.success' );
 			try { 
 				await refreshLocalImages();
 			} catch( err ) {
@@ -190,6 +191,7 @@ export async function buildImageForHash( commitHash: CommitHash ): Promise< void
 			);
 			cleanupBuildDir( commitHash );
 		} else {
+			increment( 'build.error' );
 			buildLogger.error( { err }, 'Encountered error when building image' );
 			l.error( { err, commitHash }, `Failed to build image for. Leaving build files in place` );
 			failedHashes.add( commitHash );


### PR DESCRIPTION
- A new build.error stat on the common error path
- A new build.success stat when the build works and completes
- A new timing for the refresh from the remote