### PR TITLE
Reduce the number of concurrent builds to 2

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -23,7 +23,7 @@ import { increment, timing, gauge } from './stats';
 // see https://github.com/nodegit/nodegit/pull/836
 ( git as any ).enableThreadSafety();
 
-export const MAX_CONCURRENT_BUILDS = 3;
+export const MAX_CONCURRENT_BUILDS = 2;
 export const SINGLE_BUILD_CONCURRENCY = Math.max(
 	1,
 	Math.floor( os.cpus().length / MAX_CONCURRENT_BUILDS )


### PR DESCRIPTION
When we get to 3 concurrent builds, builds get quite slow and load spikes up. Try using 2 to get 1) faster builds in general and 2) better utilization of the machine without swamping it.