### PR TITLE
Use 12 cores for all builds, allow 10 concurrent builds

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -26,10 +26,10 @@ import { increment, timing, gauge } from './stats';
 
 export const MAX_CONCURRENT_BUILDS = 4;
 
-const CORE_LIMITS = [ 8, 12, 16, 24, 32 ];
+const MAX_CORES = [ 12 ];
 export const getBuildConcurrency = () => Math.max(
 	1,
-	Math.min( Math.floor( os.cpus().length / MAX_CONCURRENT_BUILDS ), sample( CORE_LIMITS ) )
+	Math.min( Math.floor( os.cpus().length / MAX_CONCURRENT_BUILDS ), sample( MAX_CORES ) )
 );
 
 export const buildQueue: Array< CommitHash > = [];


### PR DESCRIPTION
Based on stats from grafana. No real benefit past 12 threads. Adjust the max concurrent to use as much of our 128 core builder as possible.