### PR TITLE
Adds capability for multiple Calypso environments

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -53,6 +53,10 @@ export const extractCommitFromImage = ( imageName: string ): CommitHash => {
 	return sha;
 };
 
+export const extractEnvironmentFromImage = ( image: ContainerInfo ): RunEnv => {
+	return image.Labels.calypsoEnvironment || undefined;
+}
+
 /**
  * Polls the local Docker daemon to
  * fetch an updated list of images
@@ -226,7 +230,7 @@ export async function refreshRunningContainers() {
 export function getRunningContainerForHash( hash: CommitHash, env?: RunEnv ): ContainerInfo | null {
 	const image = getImageName( hash );
 	return Array.from( state.containers.values() ).find(
-		ci => ci.Image === image && ci.State === 'running' && ( ! env || ci.Labels.calypsoEnvironment === env )
+		ci => ci.Image === image && ci.State === 'running' && ( ! env || env === extractEnvironmentFromImage( ci ) )
 	);
 }
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -43,6 +43,8 @@ export type BranchName = string;
 export type PortNumber = number;
 export type ImageStatus = 'NoImage' | 'Inactive' | PortNumber;
 
+export type RunEnv = string;
+
 export const getImageName = ( hash: CommitHash ) => `${ config.build.tagPrefix }:${ hash }`;
 export const extractCommitFromImage = ( imageName: string ): CommitHash => {
 	const [ prefix, sha ] = imageName.split( ':' );
@@ -112,12 +114,13 @@ export async function deleteImage( hash: CommitHash ) {
 		l.error( { err, commitHash: hash }, 'failed to remove image' );
 	}
 }
-export async function startContainer( commitHash: CommitHash ) {
+export async function startContainer( commitHash: CommitHash, env: RunEnv ) {
 	//l.log( { commitHash }, `Request to start a container for ${ commitHash }` );
 	const image = getImageName( commitHash );
+	const containerId = `${ env }:${ image }`;
 
 	// do we have an existing container?
-	const existingContainer = getRunningContainerForHash( commitHash );
+	const existingContainer = getRunningContainerForHash( commitHash, env );
 	if ( existingContainer ) {
 		l.log(
 			{ commitHash, containerId: existingContainer.Id },
@@ -127,12 +130,12 @@ export async function startContainer( commitHash: CommitHash ) {
 	}
 
 	// are we starting one already?
-	if ( state.startingContainers.has( commitHash ) ) {
+	if ( state.startingContainers.has( containerId ) ) {
 		//l.log( { commitHash }, `Already starting a container for ${ commitHash }` );
-		return state.startingContainers.get( commitHash );
+		return state.startingContainers.get( containerId );
 	}
 
-	async function start( image: string, commitHash: CommitHash ): Promise< ContainerInfo > {
+	async function start( image: string, commitHash: CommitHash, env: RunEnv ): Promise< ContainerInfo > {
 		// ok, try to start one
 		let freePort: number;
 		try {
@@ -160,6 +163,9 @@ export async function startContainer( commitHash: CommitHash ) {
 					ExposedPorts: { [ exposedPort ]: {} },
 					PortBindings: { [ exposedPort ]: [ { HostPort: freePort.toString() } ] },
 					Tty: false,
+					Labels: {
+						calypsoEnvironment: env,
+					},
 				},
 				err => {
 					runError = err;
@@ -194,16 +200,16 @@ export async function startContainer( commitHash: CommitHash ) {
 		);
 	}
 
-	const startPromise = start( image, commitHash );
+	const startPromise = start( image, commitHash, env );
 
-	state.startingContainers.set( commitHash, startPromise );
+	state.startingContainers.set( containerId, startPromise );
 	startPromise.then(
 		s => {
-			state.startingContainers.delete( commitHash );
+			state.startingContainers.delete( containerId );
 			return s;
 		},
 		err => {
-			state.startingContainers.delete( commitHash );
+			state.startingContainers.delete( containerId );
 			throw err;
 		}
 	);
@@ -217,15 +223,22 @@ export async function refreshRunningContainers() {
 	);
 }
 
-export function getRunningContainerForHash( hash: CommitHash ): ContainerInfo | null {
+export function getRunningContainerForHash( hash: CommitHash, env?: RunEnv ): ContainerInfo | null {
 	const image = getImageName( hash );
 	return Array.from( state.containers.values() ).find(
+		ci => ci.Image === image && ci.State === 'running' && ( ! env || ci.Labels.calypsoEnvironment === env )
+	);
+}
+
+export function getRunningContainersForHash( hash: CommitHash ): ContainerInfo[] {
+	const image = getImageName( hash );
+	return Array.from( state.containers.values() ).filter(
 		ci => ci.Image === image && ci.State === 'running'
 	);
 }
 
-export function isContainerRunning( hash: CommitHash ): boolean {
-	return !! getRunningContainerForHash( hash );
+export function isContainerRunning( hash: CommitHash, env?: RunEnv ): boolean {
+	return !! getRunningContainerForHash( hash, env );
 }
 
 export function getPortForContainer( hash: CommitHash ): number | boolean {

--- a/src/api.ts
+++ b/src/api.ts
@@ -8,7 +8,7 @@ import * as path from 'path';
 import { promisify } from 'util';
 import { ContainerInfo } from 'dockerode';
 
-import { config } from './config';
+import { config, envContainerConfig } from './config';
 import { l } from './logger';
 import { pendingHashes } from './builder';
 import { exec } from 'child_process';
@@ -41,12 +41,14 @@ export type NotFound = Error;
 export type CommitHash = string;
 export type BranchName = string;
 export type PortNumber = number;
+
+export type EnvName = string;
 export type ImageStatus = 'NoImage' | 'Inactive' | PortNumber;
 
-export const getImageName = ( hash: CommitHash ) => `${ config.build.tagPrefix }:${ hash }`;
+export const getImageName = ( hash: CommitHash, env: EnvName ) => `${ config.build.tagPrefix }${ env }:${ hash }`;
 export const extractCommitFromImage = ( imageName: string ): CommitHash => {
 	const [ prefix, sha ] = imageName.split( ':' );
-	if ( prefix !== config.build.tagPrefix ) {
+	if ( ! prefix.startsWith( config.build.tagPrefix ) ) {
 		return null;
 	}
 	return sha;
@@ -75,32 +77,32 @@ export function getLocalImages() {
 	return state.localImages;
 }
 
-export async function hasHashLocally( hash: CommitHash ): Promise< boolean > {
-	return state.localImages.has( getImageName( hash ) );
+export async function hasHashLocally( hash: CommitHash, env: EnvName ): Promise< boolean > {
+	return state.localImages.has( getImageName( hash, env ) );
 }
 
-export async function deleteImage( hash: CommitHash ) {
+export async function deleteImage( hash: CommitHash, env: EnvName ) {
 	l.log( { commitHash: hash }, 'attempting to remove image for hash' );
 
-	const runningContainer = state.containers.get( getImageName( hash ) );
+	const runningContainer = state.containers.get( getImageName( hash, env ) );
 	if ( runningContainer ) {
 		await docker.getContainer( runningContainer.Id ).stop();
 	}
 
 	let img;
 	try {
-		img = docker.getImage( getImageName( hash ) );
+		img = docker.getImage( getImageName( hash, env ) );
 		if ( ! img ) {
 			l.log(
 				{ commitHash: hash },
-				'did not have an image locally with name' + getImageName( hash )
+				'did not have an image locally with name' + getImageName( hash, env )
 			);
 			return;
 		}
 	} catch ( err ) {
 		l.log(
 			{ commitHash: hash, err },
-			'error trying to find image locally with name' + getImageName( hash )
+			'error trying to find image locally with name' + getImageName( hash, env )
 		);
 		return;
 	}
@@ -112,12 +114,12 @@ export async function deleteImage( hash: CommitHash ) {
 		l.error( { err, commitHash: hash }, 'failed to remove image' );
 	}
 }
-export async function startContainer( commitHash: CommitHash ) {
+export async function startContainer( commitHash: CommitHash, env: EnvName ) {
 	//l.log( { commitHash }, `Request to start a container for ${ commitHash }` );
-	const image = getImageName( commitHash );
+	const image = getImageName( commitHash, env );
 
 	// do we have an existing container?
-	const existingContainer = getRunningContainerForHash( commitHash );
+	const existingContainer = getRunningContainerForHash( commitHash, env );
 	if ( existingContainer ) {
 		l.log(
 			{ commitHash, containerId: existingContainer.Id },
@@ -157,6 +159,7 @@ export async function startContainer( commitHash: CommitHash ) {
 				process.stdout,
 				{
 					...config.build.containerCreateOptions,
+					...envContainerConfig( env ),
 					ExposedPorts: { [ exposedPort ]: {} },
 					PortBindings: { [ exposedPort ]: [ { HostPort: freePort.toString() } ] },
 					Tty: false,
@@ -182,7 +185,7 @@ export async function startContainer( commitHash: CommitHash ) {
 					{ image, freePort, commitHash },
 					`Successfully started container for ${ image } on ${ freePort }`
 				);
-				return refreshRunningContainers().then( () => getRunningContainerForHash( commitHash ) );
+				return refreshRunningContainers().then( () => getRunningContainerForHash( commitHash, env ) );
 			},
 			( { error, freePort } ) => {
 				l.error(
@@ -217,19 +220,19 @@ export async function refreshRunningContainers() {
 	);
 }
 
-export function getRunningContainerForHash( hash: CommitHash ): ContainerInfo | null {
-	const image = getImageName( hash );
+export function getRunningContainerForHash( hash: CommitHash, env: EnvName ): ContainerInfo | null {
+	const image = getImageName( hash, env );
 	return Array.from( state.containers.values() ).find(
 		ci => ci.Image === image && ci.State === 'running'
 	);
 }
 
-export function isContainerRunning( hash: CommitHash ): boolean {
-	return !! getRunningContainerForHash( hash );
+export function isContainerRunning( hash: CommitHash, env: EnvName ): boolean {
+	return !! getRunningContainerForHash( hash, env );
 }
 
-export function getPortForContainer( hash: CommitHash ): number | boolean {
-	const container = getRunningContainerForHash( hash );
+export function getPortForContainer( hash: CommitHash, env: EnvName ): number | boolean {
+	const container = getRunningContainerForHash( hash, env );
 
 	if ( ! container ) {
 		return false;
@@ -441,8 +444,8 @@ export async function cleanupExpiredContainers() {
 
 const proxy = httpProxy.createProxyServer( {} ); // See (†)
 export async function proxyRequestToHash( req: any, res: any ) {
-	const commitHash = req.session.commitHash;
-	let port = await getPortForContainer( commitHash );
+	const { commitHash, buildEnv } = req.session;
+	let port = await getPortForContainer( commitHash, buildEnv );
 
 	if ( ! port ) {
 		l.log( { port, commitHash }, `Could not find port for commitHash` );

--- a/src/api.ts
+++ b/src/api.ts
@@ -8,7 +8,7 @@ import * as path from 'path';
 import { promisify } from 'util';
 import { ContainerInfo } from 'dockerode';
 
-import { config } from './config';
+import { config, envContainerConfig } from './config';
 import { l } from './logger';
 import { pendingHashes } from './builder';
 import { exec } from 'child_process';
@@ -42,7 +42,6 @@ export type CommitHash = string;
 export type BranchName = string;
 export type PortNumber = number;
 export type ImageStatus = 'NoImage' | 'Inactive' | PortNumber;
-
 export type RunEnv = string;
 
 export const getImageName = ( hash: CommitHash ) => `${ config.build.tagPrefix }:${ hash }`;
@@ -160,6 +159,7 @@ export async function startContainer( commitHash: CommitHash, env: RunEnv ) {
 				process.stdout,
 				{
 					...config.build.containerCreateOptions,
+					...envContainerConfig( env ),
 					ExposedPorts: { [ exposedPort ]: {} },
 					PortBindings: { [ exposedPort ]: [ { HostPort: freePort.toString() } ] },
 					Tty: false,

--- a/src/app/debug.tsx
+++ b/src/app/debug.tsx
@@ -203,15 +203,16 @@ const Debug = ( c: RenderContext ) => {
 						) : (
 							apiContainers.map( ( [ key, info ] ) => {
 								const commit = extractCommitFromImage( info.Image );
+								const env = extractEnvironmentFromImage( info );
 								return (
 									<li key={ info.Id } className={ info.State }>
 										<strong>{ info.Names }</strong> - { shortHash( info.Id ) }
 										<br />
-										Commit: { commit ? <a href={ `/?hash=${ commit }` }>{ commit }</a> : 'none' }
+										Commit: { commit ? <a href={ `/?hash=${ commit }&env=${ env || '' }` }>{ commit }</a> : 'none' }
 										<br />
 										Image ID: { shortHash( info.ImageID ) }
 										<br />
-										Environment: { extractEnvironmentFromImage( info ) || 'unknown' }
+										Environment: { env || 'unknown' }
 										<br />
 										Status: { info.Status }
 										<br />

--- a/src/app/debug.tsx
+++ b/src/app/debug.tsx
@@ -211,6 +211,8 @@ const Debug = ( c: RenderContext ) => {
 										<br />
 										Image ID: { shortHash( info.ImageID ) }
 										<br />
+										Environment: { info.Labels.calypsoEnvironment || 'unknown' }
+										<br />
 										Status: { info.Status }
 										<br />
 										Last Access:{' '}

--- a/src/app/debug.tsx
+++ b/src/app/debug.tsx
@@ -8,7 +8,7 @@ import { Shell } from './app-shell';
 import { promiseRejections } from '../index';
 import { humanSize, humanRelativeTime, percent, round } from './util';
 
-import { state as apiState, getCommitAccessTime, extractCommitFromImage } from '../api';
+import { state as apiState, getCommitAccessTime, extractCommitFromImage, extractEnvironmentFromImage } from '../api';
 import { buildQueue, pendingHashes } from '../builder';
 
 const Docker = new Dockerode();
@@ -211,7 +211,7 @@ const Debug = ( c: RenderContext ) => {
 										<br />
 										Image ID: { shortHash( info.ImageID ) }
 										<br />
-										Environment: { info.Labels.calypsoEnvironment || 'unknown' }
+										Environment: { extractEnvironmentFromImage( info ) || 'unknown' }
 										<br />
 										Status: { info.Status }
 										<br />
@@ -279,6 +279,8 @@ const Debug = ( c: RenderContext ) => {
 										Image ID: { shortHash( info.ImageID ) }
 										<br />
 										Status: { info.State } - { info.Status }
+										<br />
+										Environment: { extractEnvironmentFromImage( info ) || 'unknown' }
 									</li>
 								) )
 						) }

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -123,8 +123,8 @@ export async function buildImageForHash( commitHash: CommitHash ): Promise< void
 
 	const buildDir = getBuildDir( commitHash );
 	const repoDir = path.join( buildDir, 'repo' );
-	const pathToLog = getLogPath( commitHash );
-	const imageName = getImageName( commitHash );
+	const logEnv = config.envs[0];
+	const imageName = getImageName( commitHash, logEnv );
 	let imageStart: number;
 
 	if ( await isBuildInProgress( commitHash ) ) {

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -123,7 +123,6 @@ export async function buildImageForHash( commitHash: CommitHash ): Promise< void
 
 	const buildDir = getBuildDir( commitHash );
 	const repoDir = path.join( buildDir, 'repo' );
-	const logEnv = config.envs[0];
 	const imageName = getImageName( commitHash );
 	let imageStart: number;
 

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -124,7 +124,7 @@ export async function buildImageForHash( commitHash: CommitHash ): Promise< void
 	const buildDir = getBuildDir( commitHash );
 	const repoDir = path.join( buildDir, 'repo' );
 	const logEnv = config.envs[0];
-	const imageName = getImageName( commitHash, logEnv );
+	const imageName = getImageName( commitHash );
 	let imageStart: number;
 
 	if ( await isBuildInProgress( commitHash ) ) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,5 @@
 import * as Dockerode from 'dockerode';
+import { RunEnv } from './api';
 
 type Readonly< T > = { readonly [ P in keyof T ]: T[ P ] };
 type AppConfig = Readonly< {
@@ -35,7 +36,7 @@ export const config: AppConfig = {
 	envs: [ 'calypso', 'jetpack' ],
 };
 
-export function envContainerConfig( environment: String = 'calypso' ): Dockerode.ContainerCreateOptions {
+export function envContainerConfig( environment: RunEnv ): Dockerode.ContainerCreateOptions {
 	switch ( environment ) {
 		case 'calypso':
 		default:

--- a/src/config.ts
+++ b/src/config.ts
@@ -25,7 +25,7 @@ export const config: AppConfig = {
 		containerCreateOptions: {},
 		exposedPort: 3000,
 		logFilename: 'dserve-build-log.txt',
-		tagPrefix: 'dserve-',
+		tagPrefix: 'dserve-wpcalypso',
 	},
 
 	repo: {

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,7 @@ type Readonly< T > = { readonly [ P in keyof T ]: T[ P ] };
 type AppConfig = Readonly< {
 	build: BuildConfig;
 	repo: RepoConfig;
+	envs: EnvsConfig;
 } >;
 
 type BuildConfig = Readonly< {
@@ -17,11 +18,11 @@ type RepoConfig = Readonly< {
 	project: string;
 } >;
 
+type EnvsConfig = Readonly<string[]>;
+
 export const config: AppConfig = {
 	build: {
-		containerCreateOptions: {
-			Env: [ 'NODE_ENV=wpcalypso', 'CALYPSO_ENV=wpcalypso' ],
-		},
+		containerCreateOptions: {},
 		exposedPort: 3000,
 		logFilename: 'dserve-build-log.txt',
 		tagPrefix: 'dserve-wpcalypso',
@@ -30,4 +31,20 @@ export const config: AppConfig = {
 	repo: {
 		project: 'Automattic/wp-calypso',
 	},
+
+	envs: [ 'calypso', 'jetpack' ],
 };
+
+export function envContainerConfig( environment: String = 'calypso' ): Dockerode.ContainerCreateOptions {
+	switch ( environment ) {
+		case 'calypso':
+		default:
+			return {
+				Env: [ 'NODE_ENV=wpcalypso', 'CALYPSO_ENV=wpcalypso' ],
+			};
+		case 'jetpack':
+			return {
+				Env: [ 'NODE_ENV=jetpack-cloud-stage', 'CALYPSO_ENV=jetpack-cloud-stage' ],
+			}
+	}
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,7 +19,7 @@ type RepoConfig = Readonly< {
 	project: string;
 } >;
 
-type EnvsConfig = Readonly<string[]>;
+type EnvsConfig = Readonly<RunEnv[]>;
 
 export const config: AppConfig = {
 	build: {

--- a/src/config.ts
+++ b/src/config.ts
@@ -25,7 +25,7 @@ export const config: AppConfig = {
 		containerCreateOptions: {},
 		exposedPort: 3000,
 		logFilename: 'dserve-build-log.txt',
-		tagPrefix: 'dserve-wpcalypso',
+		tagPrefix: 'dserve-',
 	},
 
 	repo: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,7 @@ import {
 	redirectHashFromQueryStringToSubdomain,
 	determineCommitHash,
 	session,
+	mapHostToInstanceEnv,
 } from './middlewares';
 
 import renderApp from './app/index';
@@ -143,6 +144,7 @@ calypsoServer.get( '/debug', async ( req: express.Request, res: express.Response
 
 calypsoServer.use( redirectHashFromQueryStringToSubdomain );
 calypsoServer.use( determineCommitHash );
+calypsoServer.use( mapHostToInstanceEnv );
 
 calypsoServer.get( '/status', async ( req: express.Request, res: express.Response ) => {
 	const commitHash = req.session.commitHash;
@@ -163,7 +165,8 @@ calypsoServer.get( '/status', async ( req: express.Request, res: express.Respons
 } );
 
 calypsoServer.get( '*', async ( req: express.Request, res: express.Response ) => {
-	const commitHash = req.session.commitHash;
+	const { commitHash, buildEnv } = req.session;
+	l.log( `Building in environment ${ buildEnv }` );
 	const hasLocally = await hasHashLocally( commitHash );
 	const isCurrentlyBuilding = ! hasLocally && ( await isBuildInProgress( commitHash ) );
 	const needsToBuild = ! isCurrentlyBuilding && ! hasLocally;

--- a/src/index.ts
+++ b/src/index.ts
@@ -166,7 +166,6 @@ calypsoServer.get( '/status', async ( req: express.Request, res: express.Respons
 
 calypsoServer.get( '*', async ( req: express.Request, res: express.Response ) => {
 	const { commitHash, buildEnv } = req.session;
-	l.log( `Building in environment ${ buildEnv }` );
 	const hasLocally = await hasHashLocally( commitHash, buildEnv );
 	const isCurrentlyBuilding = ! hasLocally && ( await isBuildInProgress( commitHash ) );
 	const needsToBuild = ! isCurrentlyBuilding && ! hasLocally;

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,7 @@ import {
 	redirectHashFromQueryStringToSubdomain,
 	determineCommitHash,
 	session,
-	mapHostToInstanceEnv,
+	mapQueryEnvToInstanceEnv,
 } from './middlewares';
 
 import renderApp from './app/index';
@@ -144,7 +144,7 @@ calypsoServer.get( '/debug', async ( req: express.Request, res: express.Response
 
 calypsoServer.use( redirectHashFromQueryStringToSubdomain );
 calypsoServer.use( determineCommitHash );
-calypsoServer.use( mapHostToInstanceEnv );
+calypsoServer.use( mapQueryEnvToInstanceEnv );
 
 calypsoServer.get( '/status', async ( req: express.Request, res: express.Response ) => {
 	const commitHash = req.session.commitHash;

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -57,7 +57,7 @@ export function getLoggerForBuild( commitHash: CommitHash ) {
 			},
 		],
 		commitHash,
-		imageName: getImageName( commitHash, config.envs[0] ),
+		imageName: getImageName( commitHash ),
 	} );
 
 	// we want it to be a child so that

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -57,7 +57,7 @@ export function getLoggerForBuild( commitHash: CommitHash ) {
 			},
 		],
 		commitHash,
-		imageName: getImageName( commitHash ),
+		imageName: getImageName( commitHash, config.envs[0] ),
 	} );
 
 	// we want it to be a child so that

--- a/src/middlewares.ts
+++ b/src/middlewares.ts
@@ -11,14 +11,16 @@ const hashPattern = /(?:^|.*?\.)hash-([a-f0-9]+)\./;
 function assembleSubdomainUrlForHash( req: express.Request, commitHash: CommitHash ) {
 	const protocol = req.secure || req.headers.host.indexOf( 'calypso.live' ) > -1 ? 'https' : 'http';
 
-	return (
-		protocol +
-		'://hash-' +
-		commitHash +
-		'.' +
-		stripCommitHashSubdomainFromHost( req.headers.host ) +
-		req.path
-	);
+	const newUrl = new URL( `${protocol}://hash-${commitHash}.${stripCommitHashSubdomainFromHost( req.headers.host )}` );
+	newUrl.pathname = req.path;
+	for ( let [ key, value ] of Object.entries( req.query ) ) {
+		if ( key === 'hash' || key === 'branch' ) {
+			continue;
+		}
+		newUrl.searchParams.set( key, String( value ) );
+	}
+
+	return newUrl.toString();
 }
 
 function stripCommitHashSubdomainFromHost( host: string ) {

--- a/src/middlewares.ts
+++ b/src/middlewares.ts
@@ -105,7 +105,7 @@ export function mapHostToInstanceEnv(
 	res: express.Response,
 	next: express.NextFunction,
 ) {
-	const env = config.envs.reduce( ( prev, current ) => req.hostname.includes( current ) ? current : prev, '' );
+	const env = config.envs.reduce( ( prev, current ) => req.hostname.includes( current ) ? current : prev, config.envs[0] );
 	req.session.buildEnv = env;
 	next();
 }

--- a/src/middlewares.ts
+++ b/src/middlewares.ts
@@ -100,12 +100,12 @@ export function determineCommitHash(
 	next();
 }
 
-export function mapHostToInstanceEnv(
+export function mapQueryEnvToInstanceEnv(
 	req: express.Request,
 	res: express.Response,
 	next: express.NextFunction,
 ) {
-	const env = config.envs.reduce( ( prev, current ) => req.hostname.includes( current ) ? current : prev, config.envs[0] );
+	const env = config.envs.find( env => req.query.env === env ) || config.envs[0];
 	req.session.buildEnv = env;
 	next();
 }

--- a/src/middlewares.ts
+++ b/src/middlewares.ts
@@ -4,6 +4,7 @@ import * as expressSession from 'express-session';
 
 // internal
 import { getCommitHashForBranch, refreshRemoteBranches, CommitHash, touchCommit } from './api';
+import { config } from './config';
 
 const hashPattern = /(?:^|.*?\.)hash-([a-f0-9]+)\./;
 
@@ -99,6 +100,15 @@ export function determineCommitHash(
 	next();
 }
 
+export function mapHostToInstanceEnv(
+	req: express.Request,
+	res: express.Response,
+	next: express.NextFunction,
+) {
+	const env = config.envs.reduce( ( prev, current ) => req.hostname.includes( current ) ? current : prev, '' );
+	req.session.buildEnv = env;
+	next();
+}
 export const session = expressSession( {
 	secret: 'keyboard cat',
 	cookie: {},


### PR DESCRIPTION
The goal of this PR is to allow running Calypso in a different environment depending on an optional query param.

#### Approach

1. A new middleware checks for the `env` query param against environments in the config and stores it in the session. The default is Calypso.
2. Image building is unchanged.
3. Check if image is running based off image ID as well as environment.
4. If not, start an image with correct Docker environment vars, and add a label `calypsoEnvironment` with current environment.
5. Proxy as normal.

Environments are also now visible in the debugger:

<img width="1436" alt="Screen Shot 2020-04-13 at 2 45 23 PM" src="https://user-images.githubusercontent.com/1760168/79149619-6ec19180-7d95-11ea-9764-e71013a5c17d.png">

#### Testing
* Clone branch and run `yarn install`.
* Start the app with `yarn start`.
* Once it starts, you can run a Jetpack env as `localhost:3000/?hash=[calypso commit hash]&env=jetpack`.
* You can view the status of the app on `localhost:3000/debug`.