### PR TITLE
Updates Cloud to use new horizon env

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -45,7 +45,7 @@ export function envContainerConfig( environment: RunEnv ): Dockerode.ContainerCr
 			};
 		case 'jetpack':
 			return {
-				Env: [ 'NODE_ENV=jetpack-cloud-stage', 'CALYPSO_ENV=jetpack-cloud-stage' ],
+				Env: [ 'NODE_ENV=jetpack-cloud-horizon', 'CALYPSO_ENV=jetpack-cloud-horizon' ],
 			}
 	}
 }


### PR DESCRIPTION
With the implementation of OAuth logins for Jetpack Cloud, dserve instances cannot authenticate as there is no stable URL for the OAuth redirect URI.

To fix, we've made a new config that has the OAuth functionality disabled.