### PR TITLE
Adds support to run arbitrary docker images

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,24 +3,21 @@
     // Hover to view descriptions of existing attributes.
     // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
-    "configurations": [        
+    "configurations": [
         {
-            "type": "node",
-            "request": "attach",
-            "name": "Attach",
-            "port": 9229
-        },
-        {
-            "type": "node",
             "request": "launch",
             "name": "Debug",
-            "program": "${workspaceRoot}/build/index.js",
-            "smartStep": true,
+            "program": "${workspaceFolder}/build/index.js",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
             "outFiles": [
-                "../dist/**/*.js"
+                "${workspaceFolder}/build/**/*.js",
+                "!**/node_modules/**"
             ],
             "preLaunchTask": "npm: build-ts",
-            "protocol": "inspector"
+            "type": "pwa-node",
+            "outputCapture": "std"
         }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,6 +18,19 @@
             "preLaunchTask": "npm: build-ts",
             "type": "pwa-node",
             "outputCapture": "std"
+        },
+        {
+            "request": "launch",
+            "name": "Test",
+            "program": "${workspaceFolder}/node_modules/.bin/jest",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+              "args": [
+                "--runInBand",
+                "${file}"
+            ],
+            "type": "pwa-node",
         }
     ]
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 		"@types/tar-fs": "^1.16.1",
 		"@types/useragent": "^2.1.1",
 		"bunyan": "^1.8.12",
+		"docker-parse-image": "^3.0.1",
 		"dockerode": "^3.0.0",
 		"express": "^4.16.3",
 		"express-session": "^1.15.6",

--- a/src/api.ts
+++ b/src/api.ts
@@ -527,6 +527,7 @@ export function getAllImages() {
 }
 
 export function getContainerName( container: ContainerInfo ) {
+	if ( ! container.Names || ! container.Names.length ) return null;
 	// The first character is a `/`, skip it
 	return container.Names[ 0 ].substring( 1 );
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,10 +1,10 @@
-import * as httpProxy from 'http-proxy';
-import * as Docker from 'dockerode';
-import * as _ from 'lodash';
-import * as portfinder from 'portfinder';
-import * as git from 'nodegit';
-import * as fs from 'fs-extra';
-import * as path from 'path';
+import httpProxy from 'http-proxy';
+import Docker from 'dockerode';
+import _ from 'lodash';
+import portfinder from 'portfinder';
+import git from 'nodegit';
+import fs from 'fs-extra';
+import path from 'path';
 import { promisify } from 'util';
 import { ContainerInfo } from 'dockerode';
 
@@ -45,6 +45,7 @@ export type BranchName = string;
 export type PortNumber = number;
 export type ImageStatus = 'NoImage' | 'Inactive' | PortNumber;
 export type RunEnv = string;
+export type DockerRepository = string;
 
 export const getImageName = ( hash: CommitHash ) => `${ config.build.tagPrefix }:${ hash }`;
 export const extractCommitFromImage = ( imageName: string ): CommitHash => {
@@ -504,7 +505,7 @@ export function getAllImages() {
 		Array.from( state.localImages ).reduce(
 			( images, image ) => [
 				...images,
-				...image.RepoTags.map( tag => [ tag, image ] as [ string, Docker.ImageInfo ] ),
+				...( image.RepoTags || [] ).map( tag => [ tag, image ] as [ string, Docker.ImageInfo ] ),
 			],
 			[]
 		)

--- a/src/api.ts
+++ b/src/api.ts
@@ -567,7 +567,7 @@ export async function proxyRequestToContainer( req: any, res: any, container: Co
 	const errorHandler = ( err: any ) => {
 		if ( err && ( err as any ).code === 'ECONNRESET' ) {
 			retryCounter--;
-			if ( retryCounter > 0 ) proxyToContainer();
+			if ( retryCounter > 0 ) setTimeout( proxyToContainer, 1000 );
 		}
 		l.log( { err, req, res, containerName }, 'unexpected error occured while proxying' );
 		throw new Error( 'unexpected error occured while proxying' );

--- a/src/app/app-shell.tsx
+++ b/src/app/app-shell.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { start } from 'repl';
 import { humanRelativeTime } from './util';
 import { pendingHashes, buildQueue } from '../builder';

--- a/src/app/debug.tsx
+++ b/src/app/debug.tsx
@@ -1,7 +1,7 @@
-import * as React from 'react';
-import * as ReactDOMServer from 'react-dom/server';
-import * as Dockerode from 'dockerode';
-import * as os from 'os';
+import React from 'react';
+import ReactDOMServer from 'react-dom/server';
+import Dockerode from 'dockerode';
+import os from 'os';
 
 import { ONE_MINUTE } from '../constants';
 import { Shell } from './app-shell';
@@ -119,11 +119,11 @@ const Debug = ( c: RenderContext ) => {
 			<div className="dserve-debug-cards">
 				<figure className="system">
 					<p>
-						CPU (x{ os.cpus().length }):{ ' ' }
+						CPU (x{ os.cpus().length }):{' '}
 						{ os
 							.loadavg()
 							.map( a => round( a, 2 ) )
-							.join( ', ' ) }{ ' ' }
+							.join( ', ' ) }{' '}
 						(1m, 5m, 15m)
 					</p>
 					<p>Memory</p>
@@ -145,7 +145,7 @@ const Debug = ( c: RenderContext ) => {
 						<ul>
 							{ Array.from( pendingHashes ).map( hash => (
 								<li key={ hash }>
-									<a href={ `/?hash=${ hash }` }>{ hash.substr( 0, 8 ) }</a>{ ' ' }
+									<a href={ `/?hash=${ hash }` }>{ hash.substr( 0, 8 ) }</a>{' '}
 									<a href={ `https://github.com/Automattic/wp-calypso/commit/${ hash }` }>github</a>
 								</li>
 							) ) }
@@ -160,7 +160,7 @@ const Debug = ( c: RenderContext ) => {
 						<ul>
 							{ buildQueue.map( hash => (
 								<li key={ hash }>
-									<a href={ `/?hash=${ hash }` }>{ hash.substr( 0, 8 ) }</a>{ ' ' }
+									<a href={ `/?hash=${ hash }` }>{ hash.substr( 0, 8 ) }</a>{' '}
 									<a href={ `https://github.com/Automattic/wp-calypso/commit/${ hash }` }>github</a>
 								</li>
 							) ) }
@@ -186,7 +186,7 @@ const Debug = ( c: RenderContext ) => {
 										} ) }
 									>
 										{ humanRelativeTime( ts.getTime() / 1000 ) }
-									</time>{ ' ' }
+									</time>{' '}
 									{ reason.toString() }
 								</li>
 							) ) }
@@ -214,7 +214,7 @@ const Debug = ( c: RenderContext ) => {
 									<li key={ info.Id } className={ info.State }>
 										<strong>{ info.Names }</strong> - { shortHash( info.Id ) }
 										<br />
-										Commit:{ ' ' }
+										Commit:{' '}
 										{ commit ? (
 											<a href={ `/?hash=${ commit }&env=${ env || '' }` }>{ commit }</a>
 										) : (
@@ -227,7 +227,7 @@ const Debug = ( c: RenderContext ) => {
 										<br />
 										Status: { info.Status }
 										<br />
-										Last Access:{ ' ' }
+										Last Access:{' '}
 										{ getCommitAccessTime( commit )
 											? humanRelativeTime( getCommitAccessTime( commit ) / 1000 )
 											: 'never' }
@@ -239,7 +239,7 @@ const Debug = ( c: RenderContext ) => {
 
 					<p>DServe Images</p>
 					<p>
-						Total storage size:{ ' ' }
+						Total storage size:{' '}
 						{ humanSize( images.reduce( ( size, [ , info ] ) => size + info.Size, 0 ) ) }
 					</p>
 					<ul>
@@ -250,11 +250,11 @@ const Debug = ( c: RenderContext ) => {
 						) : (
 							images.map( ( [ key, info ] ) => (
 								<li key={ info.Id }>
-									Commit:{ ' ' }
+									Commit:{' '}
 									<strong>
 										{ info.RepoTags ? (
 											<a href={ `/?hash=${ extractCommitFromImage( info.RepoTags.join( ' ' ) ) }` }>
-												{ extractCommitFromImage( info.RepoTags.join( ' ' ) ) }{ ' ' }
+												{ extractCommitFromImage( info.RepoTags.join( ' ' ) ) }{' '}
 											</a>
 										) : (
 											'None'
@@ -309,7 +309,7 @@ const Debug = ( c: RenderContext ) => {
 								.sort( ( a, b ) => b.Created - a.Created )
 								.map( info => (
 									<li key={ info.Id }>
-										RepoTags:{ ' ' }
+										RepoTags:{' '}
 										<strong>
 											{ info.RepoTags ? shortHash( info.RepoTags.join( ', ' ), 38 ) : 'None' }
 										</strong>

--- a/src/app/debug.tsx
+++ b/src/app/debug.tsx
@@ -8,7 +8,13 @@ import { Shell } from './app-shell';
 import { promiseRejections } from '../index';
 import { humanSize, humanRelativeTime, percent, round } from './util';
 
-import { state as apiState, getCommitAccessTime, extractCommitFromImage, extractEnvironmentFromImage } from '../api';
+import {
+	state as apiState,
+	getLocalImages,
+	getCommitAccessTime,
+	extractCommitFromImage,
+	extractEnvironmentFromImage,
+} from '../api';
 import { buildQueue, pendingHashes } from '../builder';
 
 const Docker = new Dockerode();
@@ -26,7 +32,7 @@ const Debug = ( c: RenderContext ) => {
 	const heapT = memUsage.heapTotal;
 	const memTotal = os.totalmem();
 	const memUsed = memTotal - os.freemem();
-	const images = Array.from( apiState.localImages.entries() ) as Array<
+	const images = Array.from( getLocalImages().entries() ) as Array<
 		[ string, Dockerode.ImageInfo ]
 	>;
 	const apiContainers = Array.from( apiState.containers.entries() );
@@ -113,11 +119,11 @@ const Debug = ( c: RenderContext ) => {
 			<div className="dserve-debug-cards">
 				<figure className="system">
 					<p>
-						CPU (x{ os.cpus().length }):{' '}
+						CPU (x{ os.cpus().length }):{ ' ' }
 						{ os
 							.loadavg()
 							.map( a => round( a, 2 ) )
-							.join( ', ' ) }{' '}
+							.join( ', ' ) }{ ' ' }
 						(1m, 5m, 15m)
 					</p>
 					<p>Memory</p>
@@ -139,7 +145,7 @@ const Debug = ( c: RenderContext ) => {
 						<ul>
 							{ Array.from( pendingHashes ).map( hash => (
 								<li key={ hash }>
-									<a href={ `/?hash=${ hash }` }>{ hash.substr( 0, 8 ) }</a>{' '}
+									<a href={ `/?hash=${ hash }` }>{ hash.substr( 0, 8 ) }</a>{ ' ' }
 									<a href={ `https://github.com/Automattic/wp-calypso/commit/${ hash }` }>github</a>
 								</li>
 							) ) }
@@ -154,7 +160,7 @@ const Debug = ( c: RenderContext ) => {
 						<ul>
 							{ buildQueue.map( hash => (
 								<li key={ hash }>
-									<a href={ `/?hash=${ hash }` }>{ hash.substr( 0, 8 ) }</a>{' '}
+									<a href={ `/?hash=${ hash }` }>{ hash.substr( 0, 8 ) }</a>{ ' ' }
 									<a href={ `https://github.com/Automattic/wp-calypso/commit/${ hash }` }>github</a>
 								</li>
 							) ) }
@@ -180,7 +186,7 @@ const Debug = ( c: RenderContext ) => {
 										} ) }
 									>
 										{ humanRelativeTime( ts.getTime() / 1000 ) }
-									</time>{' '}
+									</time>{ ' ' }
 									{ reason.toString() }
 								</li>
 							) ) }
@@ -208,7 +214,12 @@ const Debug = ( c: RenderContext ) => {
 									<li key={ info.Id } className={ info.State }>
 										<strong>{ info.Names }</strong> - { shortHash( info.Id ) }
 										<br />
-										Commit: { commit ? <a href={ `/?hash=${ commit }&env=${ env || '' }` }>{ commit }</a> : 'none' }
+										Commit:{ ' ' }
+										{ commit ? (
+											<a href={ `/?hash=${ commit }&env=${ env || '' }` }>{ commit }</a>
+										) : (
+											'none'
+										) }
 										<br />
 										Image ID: { shortHash( info.ImageID ) }
 										<br />
@@ -216,7 +227,7 @@ const Debug = ( c: RenderContext ) => {
 										<br />
 										Status: { info.Status }
 										<br />
-										Last Access:{' '}
+										Last Access:{ ' ' }
 										{ getCommitAccessTime( commit )
 											? humanRelativeTime( getCommitAccessTime( commit ) / 1000 )
 											: 'never' }
@@ -228,7 +239,7 @@ const Debug = ( c: RenderContext ) => {
 
 					<p>DServe Images</p>
 					<p>
-						Total storage size:{' '}
+						Total storage size:{ ' ' }
 						{ humanSize( images.reduce( ( size, [ , info ] ) => size + info.Size, 0 ) ) }
 					</p>
 					<ul>
@@ -239,11 +250,11 @@ const Debug = ( c: RenderContext ) => {
 						) : (
 							images.map( ( [ key, info ] ) => (
 								<li key={ info.Id }>
-									Commit:{' '}
+									Commit:{ ' ' }
 									<strong>
 										{ info.RepoTags ? (
 											<a href={ `/?hash=${ extractCommitFromImage( info.RepoTags.join( ' ' ) ) }` }>
-												{ extractCommitFromImage( info.RepoTags.join( ' ' ) ) }{' '}
+												{ extractCommitFromImage( info.RepoTags.join( ' ' ) ) }{ ' ' }
 											</a>
 										) : (
 											'None'
@@ -298,7 +309,7 @@ const Debug = ( c: RenderContext ) => {
 								.sort( ( a, b ) => b.Created - a.Created )
 								.map( info => (
 									<li key={ info.Id }>
-										RepoTags:{' '}
+										RepoTags:{ ' ' }
 										<strong>
 											{ info.RepoTags ? shortHash( info.RepoTags.join( ', ' ), 38 ) : 'None' }
 										</strong>

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
-import * as ReactDOMServer from 'react-dom/server';
+import React from 'react';
+import ReactDOMServer from 'react-dom/server';
 import { ONE_SECOND } from '../constants';
 
 import { Shell } from './app-shell';

--- a/src/app/local-images.tsx
+++ b/src/app/local-images.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
-import * as ReactDOMServer from 'react-dom/server';
-import * as Docker from 'dockerode';
+import React from 'react';
+import ReactDOMServer from 'react-dom/server';
+import Docker from 'dockerode';
 import { config } from '../config';
 
 import { Shell } from './app-shell';

--- a/src/app/log-details.tsx
+++ b/src/app/log-details.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { humanTimeSpan } from './util';
 
 const interestingDetails = new Set( [

--- a/src/app/log.tsx
+++ b/src/app/log.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
-import * as ReactDOMServer from 'react-dom/server';
+import React from 'react';
+import ReactDOMServer from 'react-dom/server';
 
 import { Shell } from './app-shell';
 import { errorClass, humanRelativeTime } from './util';

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -1,8 +1,8 @@
-import * as fs from 'fs-extra';
-import * as git from 'nodegit';
-import * as os from 'os';
-import * as path from 'path';
-import * as tar from 'tar-fs';
+import fs from 'fs-extra';
+import git from 'nodegit';
+import os from 'os';
+import path from 'path';
+import tar from 'tar-fs';
 import { Readable } from 'stream';
 import { sample } from 'lodash';
 
@@ -27,10 +27,11 @@ import { increment, timing, gauge } from './stats';
 export const MAX_CONCURRENT_BUILDS = 4;
 
 const MAX_CORES = [ 12 ];
-export const getBuildConcurrency = () => Math.max(
-	1,
-	Math.min( Math.floor( os.cpus().length / MAX_CONCURRENT_BUILDS ), sample( MAX_CORES ) )
-);
+export const getBuildConcurrency = () =>
+	Math.max(
+		1,
+		Math.min( Math.floor( os.cpus().length / MAX_CONCURRENT_BUILDS ), sample( MAX_CORES ) )
+	);
 
 export const buildQueue: Array< CommitHash > = [];
 export const pendingHashes: Set< CommitHash > = new Set();
@@ -147,7 +148,10 @@ export async function buildImageForHash( commitHash: CommitHash ): Promise< void
 	const buildConcurrency = getBuildConcurrency();
 
 	try {
-		l.log( { commitHash, buildDir, repoDir, imageName, buildConcurrency }, 'Attempting to build image.' );
+		l.log(
+			{ commitHash, buildDir, repoDir, imageName, buildConcurrency },
+			'Attempting to build image.'
+		);
 
 		const cloneStart = Date.now();
 		buildLogger.info( 'Cloning git repo' );
@@ -212,7 +216,7 @@ export async function buildImageForHash( commitHash: CommitHash ): Promise< void
 		if ( ! err ) {
 			const buildImageTime = Date.now() - imageStart;
 			timing( 'build_image', buildImageTime );
-			timing( `build_image_by_core.${buildConcurrency}_cores`, buildImageTime );
+			timing( `build_image_by_core.${ buildConcurrency }_cores`, buildImageTime );
 			increment( 'build.success' );
 			try {
 				await refreshLocalImages();

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,6 +7,7 @@ type AppConfig = Readonly< {
 	repo: RepoConfig;
 	envs: EnvsConfig;
 	allowedDockerRepositories: AllowedDockerRepositories;
+	proxyRetry: number;
 } >;
 
 type BuildConfig = Readonly< {
@@ -39,6 +40,10 @@ export const config: AppConfig = {
 	envs: [ 'calypso', 'jetpack' ],
 
 	allowedDockerRepositories: [ 'registry.a8c.com' ],
+
+	// When the proxy to the container fails with a ECONNRESET error, retry this number
+	// of times.
+	proxyRetry: 3,
 };
 
 export function envContainerConfig( environment: RunEnv ): Dockerode.ContainerCreateOptions {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,11 +1,12 @@
-import * as Dockerode from 'dockerode';
-import { RunEnv } from './api';
+import Dockerode from 'dockerode';
+import { DockerRepository, RunEnv } from './api';
 
 type Readonly< T > = { readonly [ P in keyof T ]: T[ P ] };
 type AppConfig = Readonly< {
 	build: BuildConfig;
 	repo: RepoConfig;
 	envs: EnvsConfig;
+	allowedDockerRepositories: AllowedDockerRepositories;
 } >;
 
 type BuildConfig = Readonly< {
@@ -19,7 +20,9 @@ type RepoConfig = Readonly< {
 	project: string;
 } >;
 
-type EnvsConfig = Readonly<RunEnv[]>;
+type EnvsConfig = Readonly< RunEnv[] >;
+
+type AllowedDockerRepositories = Readonly< DockerRepository[] >;
 
 export const config: AppConfig = {
 	build: {
@@ -34,6 +37,8 @@ export const config: AppConfig = {
 	},
 
 	envs: [ 'calypso', 'jetpack' ],
+
+	allowedDockerRepositories: [ 'registry.a8c.com' ],
 };
 
 export function envContainerConfig( environment: RunEnv ): Dockerode.ContainerCreateOptions {
@@ -46,6 +51,6 @@ export function envContainerConfig( environment: RunEnv ): Dockerode.ContainerCr
 		case 'jetpack':
 			return {
 				Env: [ 'NODE_ENV=jetpack-cloud-horizon', 'CALYPSO_ENV=jetpack-cloud-horizon' ],
-			}
+			};
 	}
 }

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1,4 +1,4 @@
-import * as forever from 'forever-monitor';
+import forever from 'forever-monitor';
 
 import { l } from './logger';
 

--- a/src/image-runner.ts
+++ b/src/image-runner.ts
@@ -61,6 +61,8 @@ function getContainerNameFromSubdomain( host: string ) {
  * and redirects to http://container-<containername>.calypso.live
  */
 async function loadImage( req: express.Request, res: express.Response ) {
+	res.header( 'Cache-control', 'no-cache' );
+
 	const imageName = req.query.image;
 	const environment = req.query.env || config.envs[ 0 ];
 
@@ -89,7 +91,7 @@ async function loadImage( req: express.Request, res: express.Response ) {
 
 	// Neither the container nor the image exits. Pull the image, create the container and redirect. If they image is
 	// already being pulled, this will "attach" to the output of the existing pull.
-	// TODO: This poor-man's log may cause problems if the client doesn't understand JavaScript, it will never redirect.
+	res.status( 202 );
 	res.write( '<!DOCTYPE html><body><pre>' );
 	await pullImage( imageName, data => {
 		res.write( `${ Date.now() } - ${ JSON.stringify( data ) }\n` );
@@ -97,7 +99,7 @@ async function loadImage( req: express.Request, res: express.Response ) {
 	const container = await createContainer( imageName, environment );
 	const url = assembleSubdomainUrlForContainer( req, container );
 	res.write(
-		`</pre><script>setTimeout(() => document.location.href="${ url }", 5000);</script></body>`
+		`</pre><script>setTimeout(() => document.location.replace("${ url }"), 5000);</script></body>`
 	);
 	res.end();
 }

--- a/src/image-runner.ts
+++ b/src/image-runner.ts
@@ -1,0 +1,151 @@
+// external
+import * as express from 'express';
+import { ContainerInfo } from 'dockerode';
+
+// internal
+import {
+	getAllImages,
+	findContainer,
+	pullImage,
+	deleteContainer,
+	ContainerName,
+	proxyRequestToContainer,
+	reviveContainer,
+	createContainer,
+} from './api';
+import { config } from './config';
+import { l, ringbuffer } from './logger';
+
+const imagePattern = /^container-(?<container>\w+)\./;
+
+function stripImageHashSubdomainFromHost( host: string ) {
+	return host.replace( imagePattern, '' );
+}
+
+function assembleSubdomainUrlForContainer( req: express.Request, container: ContainerInfo ) {
+	const protocol = req.secure || req.headers.host.indexOf( 'calypso.live' ) > -1 ? 'https' : 'http';
+	const environment = container.Labels[ 'calypsoEnvironment' ];
+
+	const subdomainEnv = environment && environment !== config.envs[ 0 ] ? environment + '-' : '';
+	// The first character is a `/`, skip it
+	const name = container.Names[ 0 ].substring( 1 );
+
+	const newUrl = new URL(
+		`${ protocol }://${ subdomainEnv }container-${ name }.${ stripImageHashSubdomainFromHost(
+			req.headers.host
+		) }`
+	);
+	newUrl.pathname = req.path;
+	for ( let [ key, value ] of Object.entries( req.query ) ) {
+		if ( key === 'hash' || key === 'branch' || key === 'env' || key === 'image' ) {
+			continue;
+		}
+		newUrl.searchParams.set( key, String( value ) );
+	}
+
+	return newUrl.toString();
+}
+
+function getContainerNameFromSubdomain( host: string ) {
+	const match = host.match( imagePattern );
+	if ( ! match ) {
+		return null;
+	}
+
+	return match.groups.container;
+}
+
+/**
+ * Gets an image name from the query string, finds (or creates) a container for that image
+ * and redirects to http://container-<containername>.calypso.live
+ */
+async function loadImage( req: express.Request, res: express.Response ) {
+	const imageName = req.query.image;
+	const environment = req.query.env || config.envs[ 0 ];
+
+	// There is a container for this image/environment. Redirect to http://container-<name>.calypso.live
+	const existingContainer = findContainer( {
+		image: imageName,
+		env: environment,
+	} );
+	if ( existingContainer ) {
+		res.redirect( assembleSubdomainUrlForContainer( req, existingContainer ) );
+		return;
+	}
+
+	// There is no a container for this image, but the image exists in our repo. Create the container and redirect
+	if ( getAllImages().has( imageName ) ) {
+		const container = await createContainer( imageName, environment );
+		res.redirect( assembleSubdomainUrlForContainer( req, container ) );
+		return;
+	}
+
+	// Neither the container nor the image exits. Pull the image, create the container and redirect. If they image is
+	// already being pulled, this will "attach" to the output of the existing pull.
+	// TODO: This poor-man's log may cause problems if the client doesn't understand JavaScript, it will never redirect.
+	res.write( '<!DOCTYPE html><body><pre>' );
+	await pullImage( imageName, data => {
+		res.write( `${ Date.now() } - ${ JSON.stringify( data ) }\n` );
+	} );
+	const container = await createContainer( imageName, environment );
+	const url = assembleSubdomainUrlForContainer( req, container );
+	res.write(
+		`</pre><script>setTimeout(() => document.location.href="${ url }", 5000);</script></body>`
+	);
+	res.end();
+}
+
+/**
+ * Gets a container name from the subdmain, starts it if necessary and proxies all requests to it.
+ */
+async function redirectToContainer( req: express.Request, res: express.Response ) {
+	const containerName: ContainerName = getContainerNameFromSubdomain( req.headers.host );
+	let container: ContainerInfo;
+	const shouldDelete = 'delete' in req.query;
+
+	container = findContainer( {
+		name: containerName,
+	} );
+	if ( ! container ) {
+		throw new Error( `Container ${ containerName } not found` );
+	}
+
+	if ( shouldDelete ) {
+		l.log( { containerName }, `Hard reset for ${ containerName }` );
+		await deleteContainer( container );
+		res.send( `Container ${ containerName } deleted` );
+		return;
+	}
+
+	if ( container.State !== 'running' ) {
+		container = await reviveContainer( container );
+	}
+
+	proxyRequestToContainer( req, res, container );
+}
+
+/**
+ * Main middleware for the image runner. This single middleware will take care of both cases:
+ *
+ *  - Image in query string (http://calypso.live?image=registry.a8c.com/calypso/app:build-4)
+ *  - Container name in subdomain (http://container-agitated_hypatia.calypso.live/)
+ */
+export function middleware(
+	req: express.Request,
+	res: express.Response,
+	next: express.NextFunction
+) {
+	const imageName = req.query && req.query.image;
+	if ( imageName ) {
+		loadImage( req, res ).catch( next );
+		return;
+	}
+
+	const containerName = getContainerNameFromSubdomain( req.headers.host );
+	if ( containerName ) {
+		redirectToContainer( req, res ).catch( next );
+		return;
+	}
+
+	next();
+}

--- a/src/image-runner.ts
+++ b/src/image-runner.ts
@@ -12,6 +12,8 @@ import {
 	proxyRequestToContainer,
 	reviveContainer,
 	createContainer,
+	touchContainer,
+	getContainerName,
 } from './api';
 import { config } from './config';
 import { l } from './logger';
@@ -28,8 +30,7 @@ function assembleSubdomainUrlForContainer( req: express.Request, container: Cont
 	const environment = container.Labels[ 'calypsoEnvironment' ];
 
 	const subdomainEnv = environment && environment !== config.envs[ 0 ] ? environment + '-' : '';
-	// The first character is a `/`, skip it
-	const name = container.Names[ 0 ].substring( 1 );
+	const name = getContainerName( container );
 
 	const newUrl = new URL(
 		`${ protocol }://${ subdomainEnv }container-${ name }.${ stripImageHashSubdomainFromHost(
@@ -130,6 +131,7 @@ async function startAndProxyRequestsToContainer( req: express.Request, res: expr
 		container = await reviveContainer( container );
 	}
 
+	touchContainer( containerName );
 	proxyRequestToContainer( req, res, container );
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ import {
 	session,
 	determineEnvironment,
 } from './middlewares';
-
+import { middleware as imageRunnerMiddleware } from './image-runner';
 import renderApp from './app/index';
 import renderLocalImages from './app/local-images';
 import renderLog from './app/log';
@@ -51,7 +51,7 @@ import { Writable } from 'stream';
 import {
 	refreshLocalImages,
 	refreshRemoteBranches,
-	refreshRunningContainers,
+	refreshContainers,
 	cleanupExpiredContainers,
 } from './api';
 
@@ -142,6 +142,7 @@ calypsoServer.get( '/debug', async ( req: express.Request, res: express.Response
 	}
 } );
 
+calypsoServer.use( imageRunnerMiddleware );
 calypsoServer.use( redirectHashFromQueryStringToSubdomain );
 calypsoServer.use( determineCommitHash );
 calypsoServer.use( determineEnvironment );
@@ -270,7 +271,7 @@ if ( process.env.NODE_ENV !== 'test' ) {
 	};
 
 	loop( refreshLocalImages, 5 * ONE_SECOND );
-	loop( refreshRunningContainers, 5 * ONE_SECOND );
+	loop( refreshContainers, 5 * ONE_SECOND );
 	loop( refreshRemoteBranches, ONE_MINUTE );
 	// Wait a bit before starting the expired container cleanup.
 	// This gives us some time to accumulate accesses to existing containers across app restarts

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
 // external
-import * as express from 'express';
-import * as fs from 'fs-extra';
-import * as striptags from 'striptags';
-import * as useragent from 'useragent';
+import express from 'express';
+import fs from 'fs-extra';
+import striptags from 'striptags';
+import useragent from 'useragent';
 import { exec } from 'child_process';
 
 // internal

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ import {
 	getBranchHashes,
 } from './api';
 
-import { ONE_MINUTE, ONE_SECOND } from './constants';
+import { ONE_MINUTE, ONE_SECOND, TEN_MINUTES } from './constants';
 
 import {
 	isBuildInProgress,
@@ -275,5 +275,5 @@ if ( process.env.NODE_ENV !== 'test' ) {
 	loop( refreshRemoteBranches, ONE_MINUTE );
 	// Wait a bit before starting the expired container cleanup.
 	// This gives us some time to accumulate accesses to existing containers across app restarts
-	setTimeout( () => loop( cleanupExpiredContainers, ONE_MINUTE ), 2 * ONE_MINUTE );
+	setTimeout( () => loop( cleanupExpiredContainers, ONE_MINUTE ), TEN_MINUTES );
 }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,5 +1,5 @@
-import * as bunyan from 'bunyan';
-import * as _ from 'lodash';
+import bunyan from 'bunyan';
+import _ from 'lodash';
 import { Writable } from 'stream';
 
 import { CommitHash, getImageName } from './api';

--- a/src/middlewares.ts
+++ b/src/middlewares.ts
@@ -1,19 +1,33 @@
 // external
-import * as express from 'express';
-import * as expressSession from 'express-session';
+import express from 'express';
+import expressSession from 'express-session';
 
 // internal
-import { getCommitHashForBranch, refreshRemoteBranches, CommitHash, touchCommit, RunEnv } from './api';
+import {
+	getCommitHashForBranch,
+	refreshRemoteBranches,
+	CommitHash,
+	touchCommit,
+	RunEnv,
+} from './api';
 import { config } from './config';
 
 const hashPattern = /(?:^|.*?\.)(\w*)-?hash-([a-f0-9]+)\./;
 
-function assembleSubdomainUrlForHash( req: express.Request, commitHash: CommitHash, environment: RunEnv ) {
+function assembleSubdomainUrlForHash(
+	req: express.Request,
+	commitHash: CommitHash,
+	environment: RunEnv
+) {
 	const protocol = req.secure || req.headers.host.indexOf( 'calypso.live' ) > -1 ? 'https' : 'http';
 
-	const subdomainEnv = environment && environment !== config.envs[0] ? environment + '-' : '';
+	const subdomainEnv = environment && environment !== config.envs[ 0 ] ? environment + '-' : '';
 
-	const newUrl = new URL( `${protocol}://${subdomainEnv}hash-${commitHash}.${stripCommitHashSubdomainFromHost( req.headers.host )}` );
+	const newUrl = new URL(
+		`${ protocol }://${ subdomainEnv }hash-${ commitHash }.${ stripCommitHashSubdomainFromHost(
+			req.headers.host
+		) }`
+	);
 	newUrl.pathname = req.path;
 	for ( let [ key, value ] of Object.entries( req.query ) ) {
 		if ( key === 'hash' || key === 'branch' || key === 'env' ) {
@@ -36,7 +50,7 @@ function getCommitHashFromSubdomain( host: string ) {
 		return null;
 	}
 
-	const [ /* full match */, /* environment */, hash ] = match;
+	const [ , , /* full match */ /* environment */ hash ] = match;
 	return hash;
 }
 
@@ -47,7 +61,7 @@ function getEnvironmentFromSubdomain( host: string ) {
 		return null;
 	}
 
-	const [ /* full match */, environment ] = match;
+	const [ , /* full match */ environment ] = match;
 	return environment;
 }
 
@@ -119,13 +133,13 @@ export function determineCommitHash(
 export function determineEnvironment(
 	req: express.Request,
 	res: express.Response,
-	next: express.NextFunction,
+	next: express.NextFunction
 ) {
 	const subdomainEnvironment = getEnvironmentFromSubdomain( req.headers.host );
 	if ( config.envs.includes( subdomainEnvironment ) ) {
 		req.session.runEnv = subdomainEnvironment;
 	} else {
-		req.session.runEnv = config.envs[0];
+		req.session.runEnv = config.envs[ 0 ];
 	}
 	next();
 }

--- a/src/middlewares.ts
+++ b/src/middlewares.ts
@@ -50,7 +50,9 @@ function getCommitHashFromSubdomain( host: string ) {
 		return null;
 	}
 
-	const [ , , /* full match */ /* environment */ hash ] = match;
+	// https://github.com/prettier/prettier/issues/1013
+	// prettier-ignore
+	const [ /* full match */, /* environment */, hash ] = match;
 	return hash;
 }
 
@@ -61,7 +63,9 @@ function getEnvironmentFromSubdomain( host: string ) {
 		return null;
 	}
 
-	const [ , /* full match */ environment ] = match;
+	// https://github.com/prettier/prettier/issues/1013
+	// prettier-ignore
+	const [ /* full match */, environment ] = match;
 	return environment;
 }
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,0 +1,10 @@
+declare module 'docker-parse-image' {
+	export default function parse(
+		imgName: string
+	): {
+		registry: string;
+		namespace: string;
+		repository: string;
+		tag: string;
+	};
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
 		"sourceMap": true,
 		"outDir": "build",
 		"jsx": "react",
-		"lib": [ "es7", "dom" ]
+		"lib": [ "es7", "dom" ],
+		"esModuleInterop": true
 	},
 	"include": [ "src/*" ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1377,6 +1377,11 @@ docker-modem@^2.0.0:
     split-ca "^1.0.0"
     ssh2 "^0.8.5"
 
+docker-parse-image@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/docker-parse-image/-/docker-parse-image-3.0.1.tgz#33dc69291eac3414f84871f2d59d77b6f6948be4"
+  integrity sha1-M9xpKR6sNBT4SHHy1Z13tvaUi+Q=
+
 dockerode@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/dockerode/-/dockerode-3.0.2.tgz#6e61de42ecbbae997196874e53150e3d7ae3c964"


### PR DESCRIPTION
## Background

In order to run tests in TeamCity, we need to change how `calypso.live` works. Instead of asking `dserve` to build an image based on a commit hash, we will build the image somewhere else, push it to the docker repo and ask `dserve` to download it.

See p3topS-Ok-p2 for more info

## Changes

This PR adds support for downloading and running arbitrary images. It adds two new URLs:

* `http://calypso.live?image=<image-name>`. Allows the client to specify an image to be downloaded. It can be an image from any docker registry that doesn't require credentials (limited to the registries defined in the config). It will download said image, create a container for it, and redirect the user to the URL below.
* `http://container-<container>.calypso.live`. Starts the container `<container>` as needed, and proxies all requests to it.

## Testing

- Checkout this branch and start `dserve` (it may take a while to update `wp-calypso` repo).
- Go to the URL specified in 270c2-pb. It should download it and redirect to Calypso.

Try a few variants:

- Load an image that doesn't exist locally
- In a separate tab, load an image that is being downloaded.
- Go to an image that exists locally but there are no containers for it
- Go to a container that exists but it is not started
- Go to a started container

Useful docker commands to test those variants:

- List downloaded images: `docker image ls`.
- Delete an image: `docker image rm <id> && docker image prune`
- List all containers `docker ps -a`
- Stop a running container `docker stop <id>`
- Delete a container `docker rm <id>`

## Pending things

I wanted to raise this PR when the core of the solution is done to get earlier feedback. There are still a few pending things (some of them can be addressed after this PR is merged):
- [x] touch containers so the process that clean up unused containers works as expected
- [ ] ensure that all errors are correctly propagated through the middleware layers
- [x] implement a query parameter to delete existing containers in case something breaks
- [ ] think about what info we want to add (if any) to the /debug dashboard or other debug URLs