### PR TITLE
Run pre-built images

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -112,6 +112,15 @@ export function getAllContainers() {
 	return state.containers;
 }
 
+export function isValidImage( imageInfo: ImageInfo ) {
+	if ( ! imageInfo.Labels ) return false;
+
+	for ( const [ label, value ] of Object.entries( config.allowedLabels ) ) {
+		if ( imageInfo.Labels[ label ] !== value ) return false;
+	}
+	return true;
+}
+
 export async function hasHashLocally( hash: CommitHash ): Promise< boolean > {
 	return getLocalImages().has( getImageName( hash ) );
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,6 +7,7 @@ type AppConfig = Readonly< {
 	repo: RepoConfig;
 	envs: EnvsConfig;
 	allowedDockerRepositories: AllowedDockerRepositories;
+	allowedLabels: AllowedLabels;
 	proxyRetry: number;
 } >;
 
@@ -25,6 +26,8 @@ type EnvsConfig = Readonly< RunEnv[] >;
 
 type AllowedDockerRepositories = Readonly< DockerRepository[] >;
 
+type AllowedLabels = Readonly< Record< string, string > >;
+
 export const config: AppConfig = {
 	build: {
 		containerCreateOptions: {},
@@ -40,6 +43,10 @@ export const config: AppConfig = {
 	envs: [ 'calypso', 'jetpack' ],
 
 	allowedDockerRepositories: [ 'registry.a8c.com' ],
+
+	allowedLabels: {
+		'com.a8c.image-builder': 'teamcity',
+	},
 
 	// When the proxy to the container fails with a ECONNRESET error, retry this number
 	// of times.

--- a/src/config.ts
+++ b/src/config.ts
@@ -45,7 +45,7 @@ export const config: AppConfig = {
 	allowedDockerRepositories: [ 'registry.a8c.com' ],
 
 	allowedLabels: {
-		'com.a8c.image-builder': 'teamcity',
+		'com.a8c.target': 'calypso-live',
 	},
 
 	// When the proxy to the container fails with a ECONNRESET error, retry this number

--- a/src/index.ts
+++ b/src/index.ts
@@ -142,8 +142,7 @@ calypsoServer.get( '/debug', async ( req: express.Request, res: express.Response
 	}
 } );
 
-// Disabled for now due security reasons
-// calypsoServer.use( imageRunnerMiddleware );
+calypsoServer.use( imageRunnerMiddleware );
 calypsoServer.use( redirectHashFromQueryStringToSubdomain );
 calypsoServer.use( determineCommitHash );
 calypsoServer.use( determineEnvironment );


### PR DESCRIPTION
## Background

See #190 for the main PR.

## Changes

* Enables support for running pre-built images using the url `http://calypso.live?image=<image-name>`
* Validates that the image matches some labels before running it

## Testing

- Checkout this branch and start `dserve` (it may take a while to update `wp-calypso` repo).
- Go to the URL specified in 27e43-pb. It should download it and redirect to Calypso.
