### PR TITLE
Better error control

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,9 +5,13 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "Launch",
             "request": "launch",
-            "name": "Debug",
-            "program": "${workspaceFolder}/build/index.js",
+            "runtimeArgs": [
+                "run",
+                "serve:debug"
+            ],
+            "runtimeExecutable": "yarn",
             "skipFiles": [
                 "<node_internals>/**"
             ],
@@ -21,7 +25,7 @@
         },
         {
             "request": "launch",
-            "name": "Test",
+            "name": "Run tests",
             "program": "${workspaceFolder}/node_modules/.bin/jest",
             "skipFiles": [
                 "<node_internals>/**"

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
 		"test": "jest --testURL=http://localhost/",
 		"start": "yarn run build-ts && yarn run serve",
 		"serve": "node build/index.js",
+		"serve:debug": "node build/index.js | bunyan",
 		"serve:forever": "node build/daemon.js",
 		"build-ts": "tsc",
 		"watch-ts": "tsc -w",

--- a/src/api.ts
+++ b/src/api.ts
@@ -580,17 +580,19 @@ export async function pullImage( imageName: ImageName, onProgress: ( data: any )
 
 	const stream = state.pullingImages.get( imageName );
 	return new Promise( async ( resolve, reject ) => {
-		const resolvedStream = await stream;
-
-		docker.modem.followProgress(
-			resolvedStream,
-			( err: any ) => {
-				state.pullingImages.delete( imageName );
-				if ( err ) reject( err );
-				else resolve();
-			},
-			onProgress
-		);
+		try {
+			docker.modem.followProgress(
+				await stream,
+				( err: any ) => {
+					state.pullingImages.delete( imageName );
+					if ( err ) reject( err );
+					else resolve();
+				},
+				onProgress
+			);
+		} catch( err ) {
+			reject(err);
+		}
 	} );
 }
 
@@ -622,8 +624,7 @@ export async function createContainer( imageName: ImageName, env: RunEnv ) {
 	try {
 		freePort = await getPort();
 	} catch ( err ) {
-		l.error( { err, imageName }, `Error while attempting to find a free port for ${ imageName }` );
-		throw err;
+		throw new Error(`Error while attempting to find a free port for ${ imageName }`);
 	}
 
 	try {
@@ -647,7 +648,7 @@ export async function createContainer( imageName: ImageName, env: RunEnv ) {
 			id: container.id,
 		} );
 	} catch ( error ) {
-		l.error( { imageName, error }, `Failed creating container for ${ imageName }` );
+		error.message = `Failed creating container for ${ imageName }: ` + error.message;
 		throw error;
 	}
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -648,7 +648,7 @@ export async function createContainer( imageName: ImageName, env: RunEnv ) {
 			id: container.id,
 		} );
 	} catch ( error ) {
-		error.message = `Failed creating container for ${ imageName }: ` + error.message;
+		error.message = `Failed creating container for ${ imageName }: ${error.message}`;
 		throw error;
 	}
 }

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,0 +1,26 @@
+export class ImageNotFound extends Error {
+    name: string;
+    constructor(name:string) {
+        super("Docker image not found");
+        this.name = name;
+        Error.captureStackTrace(this, ImageNotFound);
+    }
+}
+
+export class InvalidRegistry extends Error {
+    registry: string;
+    constructor(registry:string) {
+        super("Docker registry is invalid");
+        this.registry = registry;
+        Error.captureStackTrace(this, InvalidRegistry);
+    }
+}
+
+export class InvalidImage extends Error {
+    name: string;
+    constructor(name:string) {
+        super("Image is invalid");
+        this.name = name;
+        Error.captureStackTrace(this, InvalidImage);
+    }
+}

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -34,6 +34,7 @@ const dserveLogger = bunyan.createLogger( {
 /* super convenient name */
 export const l = {
 	log: dserveLogger.info.bind( dserveLogger ),
+	warn: dserveLogger.warn.bind( dserveLogger ),
 	error: dserveLogger.error.bind( dserveLogger ),
 };
 

--- a/test/logger.test.ts
+++ b/test/logger.test.ts
@@ -1,6 +1,7 @@
 jest.mock( 'bunyan', () => ( {
 	createLogger: jest.fn( () => ( {
 		info: () => {},
+		warn: () => {},
 		error: () => {},
 	} ) ),
 	RingBuffer: jest.fn(),
@@ -14,6 +15,7 @@ describe( 'logger', () => {
 		jest.resetModules();
 		logger = {
 			info: jest.fn(),
+			warn: jest.fn(),
 			error: jest.fn(),
 			child: jest.fn( options => ( { streams: options.streams } ) ),
 		};
@@ -29,6 +31,7 @@ describe( 'logger', () => {
 			const { l, closeLogger, getLoggerForBuild } = require( '../src/logger' );
 			expect( l ).toBeInstanceOf( Object );
 			expect( l.log ).toBeInstanceOf( Function );
+			expect( l.warn ).toBeInstanceOf( Function );
 			expect( l.error ).toBeInstanceOf( Function );
 		} );
 
@@ -44,9 +47,11 @@ describe( 'logger', () => {
 			const { l, closeLogger, getLoggerForBuild } = require( '../src/logger' );
 
 			l.log( 'testLog' );
+			l.warn( 'testLog' );
 			l.error( 'testLog' );
 
 			expect( logger.info.mock.calls.length ).toBe( 1 );
+			expect( logger.warn.mock.calls.length ).toBe( 1 );
 			expect( logger.error.mock.calls.length ).toBe( 1 );
 		} );
 	} );


### PR DESCRIPTION
## Change
Adds better error handling to the project:

* Use `try/catch` to detect errors from `docker.pull()`, specially useful if the image doesn't exist
* Centralized error logging in one single place. Now route handlers/middlewares `throw` errors, and rely on a error middleware to log them.
* Added error types for common scenarios. This allow the middleware logger to send a custom HTTP error instead of always 500. In the future I'll use those error types to render error screens with helpful messages.
* Reworked the logic of `loadImage()` to make it less repetitive and cover more error condition (like detecting when the image doesn't exist in the repo).

To make development a bit easer, I also added `bunyan` CLI to pretty-print the logs, and changed VSCode launch instructions to use `yarn`

## How to test
See 29ba9-pb
