### PR TITLE
Automattic for Agencies: Add support for the newly added A4A Calypso live link environment

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -40,7 +40,7 @@ export const config: AppConfig = {
 		project: 'Automattic/wp-calypso',
 	},
 
-	envs: [ 'calypso', 'jetpack' ],
+	envs: [ 'calypso', 'jetpack', 'a8c-for-agencies' ],
 
 	allowedDockerRepositories: [ 'registry.a8c.com' ],
 
@@ -63,6 +63,10 @@ export function envContainerConfig( environment: RunEnv ): Dockerode.ContainerCr
 		case 'jetpack':
 			return {
 				Env: [ 'NODE_ENV=jetpack-cloud-horizon', 'CALYPSO_ENV=jetpack-cloud-horizon' ],
+			};
+		case 'a8c-for-agencies':
+			return {
+				Env: [ 'NODE_ENV=a8c-for-agencies-horizon', 'CALYPSO_ENV=a8c-for-agencies-horizon' ],
 			};
 	}
 }


### PR DESCRIPTION
## Background

To test the changes done to the newly added environment for Automattic for Agencies on Calypso live links, we need to update the environments here to support that environment.

## Changes

This PR 

- Adds `a8c-for-agencies` to the `envs` in the `src/config.ts` file.
- Adds a new `case` to the switch statement for `a8c-for-agencies` that returns `Env` resolving NODE_ENV and CALYPSO_ENV to `a8c-for-agencies-horizon`.

## Testing

- Check out this branch and start `dserve` (it may take a while to update the `wp-calypso` repo).
- Go to the URL specified in 33ce4-pb/#plain > It should download the image > Verify that you are redirected to Calypso (Automattic for Agencies). Please ignore the empty page.

<img width="610" alt="Screenshot 2024-03-12 at 5 38 24 PM" src="https://github.com/Automattic/dserve/assets/10586875/cfa24014-5540-4d6e-949e-c4e7ac9198dd">