### PR TITLE
Upgrade CircleCI Node image from v10 to v20

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:10
+      - image: cimg/node:20.11.0
 
     working_directory: ~/repo
 


### PR DESCRIPTION
I tried this Node CircleCI container upgrade in hope to fix failing CircleCI checks. But it still doesn't work, CircleCI fails right at initialization, when trying to checkout the dserve repo from GitHub:
```
Cloning git repository
        - Creating a blobless clone for better performance
Cloning into '.'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
error running git clone "git@github.com:Automattic/dserve.git": exit status 128
```