### PR TITLE
Use BuildKit for hash builds and fail if the image is not loaded locally

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -7,6 +7,7 @@ import { sample } from 'lodash';
 import {
 	CommitHash,
 	getImageName,
+	getLocalImages,
 	docker,
 	refreshLocalImages,
 	refreshRemoteBranches,
@@ -168,6 +169,8 @@ export async function buildImageForHash( commitHash: CommitHash ): Promise< void
 			t: imageName,
 			nocache: false,
 			forcerm: true,
+			version: '2',
+			outputs: JSON.stringify( [ { type: 'image', attrs: { name: imageName } } ] ),
 			buildargs: {
 				commit_sha: commitHash,
 				workers: String( buildConcurrency ),
@@ -204,8 +207,30 @@ export async function buildImageForHash( commitHash: CommitHash ): Promise< void
 			increment( 'build.success' );
 			try {
 				await refreshLocalImages();
+				const imageLoadedLocally = getLocalImages().has( imageName );
+				l.info(
+					{ commitHash, imageName, imageLoadedLocally },
+					'Checked whether the built image is available locally after refresh'
+				);
+				if ( ! imageLoadedLocally ) {
+					throw new Error(
+						`Build completed but image ${ imageName } is not available locally after refresh`
+					);
+				}
 			} catch ( err ) {
-				l.info( { commitHash, err }, 'Error refreshing local images' );
+				increment( 'build.error' );
+				buildLogger.error(
+					{ err },
+					'Built image stream completed but the image was not available locally'
+				);
+				l.error(
+					{ err, commitHash, imageName },
+					'Built image stream completed but the image was not available locally'
+				);
+				failedHashes.add( commitHash );
+				pendingHashes.delete( commitHash );
+				closeLogger( buildLogger as any );
+				return;
 			}
 			l.info(
 				{ commitHash, buildImageTime, repoDir, imageName, buildConcurrency },


### PR DESCRIPTION
Issue: [TESTOPS-82](https://linear.app/a8c/issue/TESTOPS-82/calypso-live-docker-build-fails-due-to-unsupported-parents-flag-in)

## Summary

This updates the hash-build path to use the BuildKit builder through the Docker Engine API and verifies that the finished build actually produced a locally-available image for dserve to run.

## What changed

- send version: '2' on docker.buildImage(...) so the Engine API uses the BuildKit-capable builder path
- add an explicit build output/export so the result is produced as a named image
- after the build completes, refresh local images and verify that the expected dserve-wpcalypso:<sha> tag is actually present
- treat “build stream completed but no local image exists” as a build failure instead of logging a false success

## Why

Calypso’s Dockerfile now relies on BuildKit features such as COPY --parents, which do not work on the old builder path. We also found that a successful build stream was not enough by itself for dserve, because dserve needs the resulting image to be available in the local
Docker image store under the expected tag before it can reuse it for hash requests.

## Validation

- ./node_modules/.bin/tsc -p tsconfig.json
- ./node_modules/.bin/jest --no-cache --runInBand
- http://calypso.localhost:3000/?hash=eaea67502d2a93bbf48116bc80016092e8217255&reset=1
