### PR TITLE
Improve build failure reporting for BuildKit hash builds

### DIFF
--- a/src/app/log-details.tsx
+++ b/src/app/log-details.tsx
@@ -14,6 +14,7 @@ const interestingDetails = new Set( [
 	'err',
 	'error',
 	'freePort',
+	'imageLoadedLocally',
 	'imageName',
 	'reason',
 	'signal',
@@ -44,7 +45,7 @@ const LogDetails = ( { data, details }: any ) => {
 	details = details || interestingDetails;
 	const detailsToShow = new Map();
 	for ( let detail of details ) {
-		if ( data[ detail ] ) {
+		if ( data[ detail ] !== undefined && data[ detail ] !== null ) {
 			detailsToShow.set( detail, data[ detail ] );
 		}
 	}

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -7,6 +7,7 @@ import { sample } from 'lodash';
 import {
 	CommitHash,
 	getImageName,
+	getLocalImages,
 	docker,
 	refreshLocalImages,
 	refreshRemoteBranches,
@@ -168,6 +169,8 @@ export async function buildImageForHash( commitHash: CommitHash ): Promise< void
 			t: imageName,
 			nocache: false,
 			forcerm: true,
+			version: '2',
+			outputs: JSON.stringify( [ { type: 'image', attrs: { name: imageName } } ] ),
 			buildargs: {
 				commit_sha: commitHash,
 				workers: String( buildConcurrency ),
@@ -204,8 +207,30 @@ export async function buildImageForHash( commitHash: CommitHash ): Promise< void
 			increment( 'build.success' );
 			try {
 				await refreshLocalImages();
+				const imageLoadedLocally = getLocalImages().has( imageName );
+				l.info(
+					{ commitHash, imageName, imageLoadedLocally },
+					'Checked whether the built image is available locally after refresh'
+				);
+				if ( ! imageLoadedLocally ) {
+					throw new Error(
+						`Build completed but image ${ imageName } is not available locally after refresh`
+					);
+				}
 			} catch ( err ) {
-				l.info( { commitHash, err }, 'Error refreshing local images' );
+				increment( 'build.error' );
+				buildLogger.error(
+					{ err },
+					'Built image stream completed but the image was not available locally'
+				);
+				l.error(
+					{ err, commitHash, imageName },
+					'Built image stream completed but the image was not available locally'
+				);
+				failedHashes.add( commitHash );
+				pendingHashes.delete( commitHash );
+				closeLogger( buildLogger as any );
+				return;
 			}
 			l.info(
 				{ commitHash, buildImageTime, repoDir, imageName, buildConcurrency },

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -31,6 +31,24 @@ export const buildQueue: Array< CommitHash > = [];
 export const pendingHashes: Set< CommitHash > = new Set();
 const failedHashes: Set< CommitHash > = new Set();
 
+function getBuildStreamError( output: any[] = [] ): Error | null {
+	for ( const event of [ ...output ].reverse() ) {
+		if ( ! event || typeof event !== 'object' ) {
+			continue;
+		}
+
+		const message =
+			event.errorDetail?.message ||
+			event.error ||
+			event.message;
+		if ( message ) {
+			return new Error( message );
+		}
+	}
+
+	return null;
+}
+
 export const getLogPath = ( hash: CommitHash ) =>
 	path.join( getBuildDir( hash ), config.build.logFilename );
 export async function isBuildInProgress( hash: CommitHash ): Promise< boolean > {
@@ -199,7 +217,22 @@ export async function buildImageForHash( commitHash: CommitHash ): Promise< void
 		return;
 	}
 
-	async function onFinished( err: Error ) {
+	async function onFinished( err: Error, output: any[] = [] ) {
+		const streamErr = err || getBuildStreamError( output );
+
+		if ( streamErr ) {
+			increment( 'build.error' );
+			buildLogger.error( { err: streamErr, output }, 'Encountered error when building image' );
+			l.error(
+				{ err: streamErr, commitHash },
+				`Failed to build image for. Leaving build files in place`
+			);
+			failedHashes.add( commitHash );
+			pendingHashes.delete( commitHash );
+			closeLogger( buildLogger as any );
+			return;
+		}
+
 		if ( ! err ) {
 			const buildImageTime = Date.now() - imageStart;
 			timing( 'build_image', buildImageTime );
@@ -220,7 +253,7 @@ export async function buildImageForHash( commitHash: CommitHash ): Promise< void
 			} catch ( err ) {
 				increment( 'build.error' );
 				buildLogger.error(
-					{ err },
+					{ err, output },
 					'Built image stream completed but the image was not available locally'
 				);
 				l.error(
@@ -237,11 +270,6 @@ export async function buildImageForHash( commitHash: CommitHash ): Promise< void
 				`Successfully built image. Now cleaning up build directory`
 			);
 			cleanupBuildDir( commitHash );
-		} else {
-			increment( 'build.error' );
-			buildLogger.error( { err }, 'Encountered error when building image' );
-			l.error( { err, commitHash }, `Failed to build image for. Leaving build files in place` );
-			failedHashes.add( commitHash );
 		}
 		pendingHashes.delete( commitHash );
 		closeLogger( buildLogger as any );


### PR DESCRIPTION
Issue: [TESTOPS-82](https://linear.app/a8c/issue/TESTOPS-82/calypso-live-docker-build-fails-due-to-unsupported-parents-flag-in)

# Blocked

This PR is blocked on #239 - it includes its changes and assumes it has already been deployed.

## Summary

This improves error handling and log visibility around hash builds so dserve reports real BuildKit failures instead of occasionally logging a false success.

## What changed

- inspect the final Docker build output stream for embedded build errors, not just transport-level callback errors
- treat streamed BuildKit errors as real build failures and keep the build directory/logs in place for debugging
- include build output in the “image was not available locally” error path
- fix /log detail rendering so falsey values like imageLoadedLocally: false are displayed
- add imageLoadedLocally to the rendered log detail allowlist

## Why

With the BuildKit-based build path, some failures were being reported inside the streamed build events rather than as the top-level callback error. That could make dserve log “Successfully built image” even when no runnable image had actually been produced. This change makes those failures visible and makes the /log page more useful when diagnosing build/export issues.

## Validation

- ./node_modules/.bin/tsc -p tsconfig.json
- ./node_modules/.bin/jest --no-cache --runInBand
- http://calypso.localhost:3000/?hash=eaea67502d2a93bbf48116bc80016092e8217255&reset=1