### PR TITLE
Pin GitHub Actions dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,16 +6,21 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     name: Validate
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        # actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        # actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version-file: .nvmrc
 


### PR DESCRIPTION
## Summary
- Upgrade `actions/checkout` and `actions/setup-node` to their Node 24 `v5` releases.
- Pin both actions to full commit SHAs instead of mutable tags.
- Restrict workflow token permissions to `contents: read`.

Pinned versions:
- `actions/checkout@v5` => `93cb6efe18208431cddfb8368fd83d5badbf9bfd`
- `actions/setup-node@v5` => `a0853c24544627f65ddf259abe73b1d18a591444`

## Testing
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "workflow yaml ok"'`
- `git diff --check`