### PR TITLE
Replace dashboard-ciab with dashboard-a4a

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -765,10 +765,10 @@ export async function createContainer( imageName: ImageName, env: RunEnv ) {
 			},
 		} );
 
-		if (env === 'dashboard-ciab') {
-			// Append a `-ciab` suffix to the container name
+		if (env === 'dashboard-a4a') {
+			// Append a `-a4a` suffix to the container name
 			const info = await container.inspect();
-			await container.rename({ name: `${info.Name.substring(1)}-ciab` });
+			await container.rename({ name: `${info.Name.substring(1)}-a4a` });
 		}
 
 		l.info( { imageName }, `Successfully created container for ${ imageName }` );

--- a/src/config.ts
+++ b/src/config.ts
@@ -40,7 +40,7 @@ export const config: AppConfig = {
 		project: 'Automattic/wp-calypso',
 	},
 
-	envs: [ 'calypso', 'jetpack', 'a8c-for-agencies', 'dashboard', 'dashboard-ciab' ],
+	envs: [ 'calypso', 'jetpack', 'a8c-for-agencies', 'dashboard', 'dashboard-a4a' ],
 
 	allowedDockerRepositories: [ 'registry.a8c.com' ],
 
@@ -69,7 +69,7 @@ export function envContainerConfig( environment: RunEnv ): Dockerode.ContainerCr
 				Env: [ 'NODE_ENV=a8c-for-agencies-horizon', 'CALYPSO_ENV=a8c-for-agencies-horizon' ],
 			};
     case 'dashboard':
-    case 'dashboard-ciab':
+    case 'dashboard-a4a':
 			return {
 				Env: [ 'NODE_ENV=dashboard-horizon', 'CALYPSO_ENV=dashboard-horizon' ],
 			};


### PR DESCRIPTION
Repurpose dashboard-ciab Calypso Live link infrastructure for A4A.

cc: @Automattic/a4a-genesis 